### PR TITLE
Toggle world abnormal state with O key

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -96,5 +96,11 @@ namespace LSP.Gameplay
                 instance = null;
             }
         }
+
+        private void Update()
+        {
+            var shouldBeAbnormal = Input.GetKey(KeyCode.O);
+            SetWorldAbnormalState(shouldBeAbnormal);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add an Update loop to GameManager so holding the O key enables the abnormal world state and releasing it returns to normal

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68d32c1654ec83319330627ad5936636