### PR TITLE
Implement player interaction system

### DIFF
--- a/Assets/Scripts/DisablerDevice.cs
+++ b/Assets/Scripts/DisablerDevice.cs
@@ -31,6 +31,10 @@ namespace LSP.Gameplay
 
         public DisablerState CurrentState { get; private set; } = DisablerState.Broken;
 
+        public int FragmentsRequired => fragmentsRequired;
+
+        public int CollectedFragments => collectedFragments;
+
         private void Awake()
         {
             if (effectOrigin == null)
@@ -44,7 +48,21 @@ namespace LSP.Gameplay
         /// </summary>
         public void AddRepairFragment()
         {
-            collectedFragments = Mathf.Min(collectedFragments + 1, fragmentsRequired);
+            AddRepairFragments(1);
+        }
+
+        /// <summary>
+        /// Adds multiple repair fragments to the device at once. Returns the updated fragment count.
+        /// </summary>
+        public int AddRepairFragments(int amount)
+        {
+            if (amount <= 0)
+            {
+                return collectedFragments;
+            }
+
+            collectedFragments = Mathf.Clamp(collectedFragments + amount, 0, fragmentsRequired);
+            return collectedFragments;
         }
 
         /// <summary>

--- a/Assets/Scripts/Interactions/IInteractable.cs
+++ b/Assets/Scripts/Interactions/IInteractable.cs
@@ -1,0 +1,20 @@
+namespace LSP.Gameplay.Interactions
+{
+    /// <summary>
+    /// Describes an object that can be interacted with by the player.
+    /// </summary>
+    public interface IInteractable
+    {
+        /// <summary>
+        /// Returns true if the interactable can currently be activated by the specified caller.
+        /// </summary>
+        /// <param name="caller">Controller attempting to interact.</param>
+        bool CanInteract(LSP.Gameplay.PlayerInteractionController caller);
+
+        /// <summary>
+        /// Performs the interaction behaviour for the given caller.
+        /// </summary>
+        /// <param name="caller">Controller invoking the interaction.</param>
+        void Interact(LSP.Gameplay.PlayerInteractionController caller);
+    }
+}

--- a/Assets/Scripts/Interactions/InteractableItem.cs
+++ b/Assets/Scripts/Interactions/InteractableItem.cs
@@ -1,0 +1,287 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace LSP.Gameplay.Interactions
+{
+    /// <summary>
+    /// Represents an interactable pickup item in the world that can either be carried or consumed.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class InteractableItem : MonoBehaviour, IInteractable
+    {
+        public enum PickupMode
+        {
+            FloatingCarry,
+            ConsumableFragment
+        }
+
+        [Header("Pickup Behaviour")]
+        [SerializeField]
+        private PickupMode pickupMode = PickupMode.FloatingCarry;
+
+        [SerializeField]
+        [Tooltip("Number of fragments granted to the disabler device when consumed.")]
+        private int fragmentValue = 1;
+
+        [Header("Carry Anchor Pose")]
+        [SerializeField]
+        private Vector3 carriedLocalPosition;
+
+        [SerializeField]
+        private Vector3 carriedLocalEulerAngles;
+
+        [SerializeField]
+        private Vector3 carriedLocalScale = Vector3.one;
+
+        [Header("Lock Interaction")]
+        [SerializeField]
+        [Tooltip("Radius around the item to check for lock interaction trigger volumes while carried.")]
+        private float lockDetectionRadius = 0.5f;
+
+        [SerializeField]
+        [Tooltip("Layers considered when searching for lock interaction volumes.")]
+        private LayerMask lockZoneLayers = ~0;
+
+        [SerializeField]
+        [Tooltip("Optional tag filter applied when identifying lock interaction zones.")]
+        private string lockZoneTag = "LockInteraction";
+
+        [SerializeField]
+        [Tooltip("Colliders that should become active while the item is carried to support trigger-only interactions.")]
+        private Collider[] autoInteractionColliders;
+
+        private readonly List<LockInteractionZone> activeLockZones = new List<LockInteractionZone>();
+        private readonly HashSet<LockInteractionZone> lockZoneBuffer = new HashSet<LockInteractionZone>();
+        private readonly Collider[] overlapResults = new Collider[8];
+
+        private PlayerInteractionController currentCarrier;
+        private Transform originalParent;
+        private Vector3 originalLocalPosition;
+        private Quaternion originalLocalRotation;
+        private Vector3 originalLocalScale;
+        private bool isCarried;
+
+        /// <summary>
+        /// Gets a value indicating whether the item is currently being carried by a player.
+        /// </summary>
+        public bool IsCarried => isCarried;
+
+        private void Awake()
+        {
+            CacheOriginalTransform();
+            ConfigureAutoInteractionColliders(false);
+        }
+
+        private void OnDisable()
+        {
+            if (currentCarrier != null)
+            {
+                currentCarrier.NotifyItemReleased(this);
+            }
+
+            ClearLockZones();
+        }
+
+        private void Update()
+        {
+            if (!isCarried)
+            {
+                return;
+            }
+
+            UpdateLockZoneTracking();
+        }
+
+        /// <inheritdoc />
+        public bool CanInteract(PlayerInteractionController caller)
+        {
+            if (pickupMode == PickupMode.FloatingCarry)
+            {
+                return !isCarried || currentCarrier == caller;
+            }
+
+            return true;
+        }
+
+        /// <inheritdoc />
+        public void Interact(PlayerInteractionController caller)
+        {
+            if (pickupMode == PickupMode.FloatingCarry)
+            {
+                if (isCarried)
+                {
+                    if (currentCarrier == caller)
+                    {
+                        ReleaseFromCarrier();
+                    }
+                    return;
+                }
+
+                BeginCarry(caller);
+                return;
+            }
+
+            Consume(caller);
+        }
+
+        internal void HandleInteractWhileCarried(PlayerInteractionController caller)
+        {
+            if (pickupMode == PickupMode.FloatingCarry && currentCarrier == caller)
+            {
+                ReleaseFromCarrier();
+            }
+        }
+
+        internal void ReleaseFromCarrier()
+        {
+            if (!isCarried)
+            {
+                return;
+            }
+
+            isCarried = false;
+
+            if (currentCarrier != null)
+            {
+                currentCarrier.NotifyItemReleased(this);
+            }
+
+            transform.SetParent(originalParent, false);
+            transform.localPosition = originalLocalPosition;
+            transform.localRotation = originalLocalRotation;
+            transform.localScale = originalLocalScale;
+
+            currentCarrier = null;
+            ConfigureAutoInteractionColliders(false);
+            ClearLockZones();
+        }
+
+        internal void NotifyLockInteractionComplete(LockInteractionZone zone)
+        {
+            if (activeLockZones.Contains(zone))
+            {
+                zone.CancelInteraction(this);
+                activeLockZones.Remove(zone);
+            }
+        }
+
+        private void BeginCarry(PlayerInteractionController caller)
+        {
+            if (caller == null)
+            {
+                return;
+            }
+
+            CacheOriginalTransform();
+
+            currentCarrier = caller;
+            currentCarrier.NotifyItemCarried(this);
+
+            var anchor = caller.CarryAnchor;
+            transform.SetParent(anchor, false);
+            transform.localPosition = carriedLocalPosition;
+            transform.localRotation = Quaternion.Euler(carriedLocalEulerAngles);
+            transform.localScale = carriedLocalScale;
+
+            isCarried = true;
+            ConfigureAutoInteractionColliders(true);
+        }
+
+        private void Consume(PlayerInteractionController caller)
+        {
+            if (fragmentValue > 0 && caller != null && caller.DisablerDevice != null)
+            {
+                caller.DisablerDevice.AddRepairFragments(fragmentValue);
+            }
+
+            Destroy(gameObject);
+        }
+
+        private void CacheOriginalTransform()
+        {
+            originalParent = transform.parent;
+            originalLocalPosition = transform.localPosition;
+            originalLocalRotation = transform.localRotation;
+            originalLocalScale = transform.localScale;
+        }
+
+        private void UpdateLockZoneTracking()
+        {
+            if (lockDetectionRadius <= 0f)
+            {
+                return;
+            }
+
+            int hitCount = Physics.OverlapSphereNonAlloc(transform.position, lockDetectionRadius, overlapResults, lockZoneLayers, QueryTriggerInteraction.Collide);
+            lockZoneBuffer.Clear();
+
+            for (int i = 0; i < hitCount; i++)
+            {
+                var collider = overlapResults[i];
+                if (collider == null)
+                {
+                    continue;
+                }
+
+                if (!string.IsNullOrEmpty(lockZoneTag) && !collider.CompareTag(lockZoneTag))
+                {
+                    continue;
+                }
+
+                if (!collider.TryGetComponent(out LockInteractionZone zone))
+                {
+                    continue;
+                }
+
+                lockZoneBuffer.Add(zone);
+                if (!activeLockZones.Contains(zone))
+                {
+                    activeLockZones.Add(zone);
+                    zone.BeginInteraction(this);
+                }
+
+                zone.ProcessInteraction(this, Time.deltaTime);
+            }
+
+            for (int i = activeLockZones.Count - 1; i >= 0; i--)
+            {
+                var zone = activeLockZones[i];
+                if (!lockZoneBuffer.Contains(zone))
+                {
+                    zone.CancelInteraction(this);
+                    activeLockZones.RemoveAt(i);
+                }
+            }
+        }
+
+        private void ConfigureAutoInteractionColliders(bool enabled)
+        {
+            if (autoInteractionColliders == null)
+            {
+                return;
+            }
+
+            foreach (var collider in autoInteractionColliders)
+            {
+                if (collider == null)
+                {
+                    continue;
+                }
+
+                collider.enabled = enabled;
+            }
+        }
+
+        private void ClearLockZones()
+        {
+            for (int i = activeLockZones.Count - 1; i >= 0; i--)
+            {
+                var zone = activeLockZones[i];
+                zone?.CancelInteraction(this);
+            }
+
+            activeLockZones.Clear();
+            lockZoneBuffer.Clear();
+        }
+    }
+}

--- a/Assets/Scripts/Interactions/LockInteractionZone.cs
+++ b/Assets/Scripts/Interactions/LockInteractionZone.cs
@@ -1,0 +1,112 @@
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace LSP.Gameplay.Interactions
+{
+    /// <summary>
+    /// Represents a trigger volume that can be completed by holding a carried item within it.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class LockInteractionZone : MonoBehaviour
+    {
+        [System.Serializable]
+        public class ProgressEvent : UnityEvent<float>
+        {
+        }
+
+        [Header("Progress Settings")]
+        [SerializeField]
+        [Tooltip("Seconds the carried item must remain in the zone to complete the lock interaction.")]
+        private float requiredHoldTime = 2f;
+
+        [Header("Events")]
+        [SerializeField]
+        private ProgressEvent progressUpdated;
+
+        [SerializeField]
+        private UnityEvent onLockCompleted;
+
+        private InteractableItem activeItem;
+        private float currentProgress;
+
+        /// <summary>
+        /// Begins tracking the supplied item within the lock zone.
+        /// </summary>
+        public void BeginInteraction(InteractableItem item)
+        {
+            if (item == null)
+            {
+                return;
+            }
+
+            if (activeItem != null && activeItem != item)
+            {
+                return;
+            }
+
+            activeItem = item;
+            currentProgress = Mathf.Clamp(currentProgress, 0f, requiredHoldTime);
+            NotifyProgress();
+        }
+
+        /// <summary>
+        /// Processes an interaction tick for the active item.
+        /// </summary>
+        public void ProcessInteraction(InteractableItem item, float deltaTime)
+        {
+            if (item == null || item != activeItem)
+            {
+                return;
+            }
+
+            if (requiredHoldTime <= 0f)
+            {
+                CompleteInteraction();
+                return;
+            }
+
+            currentProgress = Mathf.Min(requiredHoldTime, currentProgress + Mathf.Max(0f, deltaTime));
+            NotifyProgress();
+
+            if (currentProgress >= requiredHoldTime)
+            {
+                CompleteInteraction();
+            }
+        }
+
+        /// <summary>
+        /// Cancels the current interaction attempt, resetting progress if the supplied item matches the active one.
+        /// </summary>
+        public void CancelInteraction(InteractableItem item)
+        {
+            if (item == null || item != activeItem)
+            {
+                return;
+            }
+
+            activeItem = null;
+            currentProgress = 0f;
+            NotifyProgress();
+        }
+
+        private void CompleteInteraction()
+        {
+            onLockCompleted?.Invoke();
+            activeItem?.NotifyLockInteractionComplete(this);
+            activeItem = null;
+            currentProgress = 0f;
+            NotifyProgress();
+        }
+
+        private void NotifyProgress()
+        {
+            if (progressUpdated == null)
+            {
+                return;
+            }
+
+            float target = requiredHoldTime <= 0f ? 1f : Mathf.Clamp01(currentProgress / requiredHoldTime);
+            progressUpdated.Invoke(target);
+        }
+    }
+}

--- a/Assets/Scripts/PlayerInteractionController.cs
+++ b/Assets/Scripts/PlayerInteractionController.cs
@@ -1,0 +1,223 @@
+using UnityEngine;
+using LSP.Gameplay.Interactions;
+
+namespace LSP.Gameplay
+{
+    /// <summary>
+    /// Handles player driven interactions by raycasting from the active camera and invoking
+    /// the focused <see cref="IInteractable"/> when prompted.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class PlayerInteractionController : MonoBehaviour
+    {
+        [Header("Interaction")]
+        [SerializeField]
+        private KeyCode interactKey = KeyCode.F;
+
+        [SerializeField]
+        [Tooltip("Camera used to perform interaction raycasts. Defaults to the main camera if left empty.")]
+        private Camera interactionCamera;
+
+        [SerializeField]
+        [Tooltip("Maximum distance from the camera that the player can interact with objects.")]
+        private float interactionDistance = 3f;
+
+        [SerializeField]
+        [Tooltip("Physics layers considered valid when searching for interactables.")]
+        private LayerMask interactableLayers = ~0;
+
+        [Header("Dependencies")]
+        [SerializeField]
+        private PlayerEyeControl eyeControl;
+
+        [SerializeField]
+        private DisablerDevice disablerDevice;
+
+        private IInteractable currentInteractable;
+        private InteractableItem carriedItem;
+        private bool uiOpen;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the player's interaction input is currently blocked by UI.
+        /// </summary>
+        public bool IsUiOpen
+        {
+            get => uiOpen;
+            set => uiOpen = value;
+        }
+
+        /// <summary>
+        /// Returns the transform used as the anchor for carried items.
+        /// </summary>
+        public Transform CarryAnchor => interactionCamera != null ? interactionCamera.transform : transform;
+
+        /// <summary>
+        /// Provides the active disabler device so consumable items can update fragment counts.
+        /// </summary>
+        public DisablerDevice DisablerDevice => disablerDevice;
+
+        /// <summary>
+        /// The interactable item currently being carried by the player, if any.
+        /// </summary>
+        public InteractableItem CarriedItem => carriedItem;
+
+        private void Awake()
+        {
+            if (interactionCamera == null)
+            {
+                interactionCamera = GetComponentInChildren<Camera>();
+                if (interactionCamera == null)
+                {
+                    interactionCamera = Camera.main;
+                }
+            }
+
+            if (eyeControl == null)
+            {
+                eyeControl = GetComponent<PlayerEyeControl>();
+            }
+
+            if (eyeControl == null)
+            {
+                eyeControl = GetComponentInChildren<PlayerEyeControl>();
+            }
+        }
+
+        private void OnDisable()
+        {
+            ClearFocus();
+            DropCarriedItem();
+        }
+
+        private void Update()
+        {
+            if (interactionCamera == null)
+            {
+                return;
+            }
+
+            if (IsInteractionSuspended())
+            {
+                ClearFocus();
+                return;
+            }
+
+            UpdateFocus();
+            HandleInteractionInput();
+        }
+
+        /// <summary>
+        /// Updates the reference to the disabler device that should receive fragment counts.
+        /// </summary>
+        public void SetDisablerDevice(DisablerDevice device)
+        {
+            disablerDevice = device;
+        }
+
+        /// <summary>
+        /// Sets the eye control dependency used to determine when the player is blinking.
+        /// </summary>
+        public void SetEyeControl(PlayerEyeControl control)
+        {
+            eyeControl = control;
+        }
+
+        /// <summary>
+        /// Drops the currently carried item (if any) and restores its original transform hierarchy.
+        /// </summary>
+        public void DropCarriedItem()
+        {
+            if (carriedItem == null)
+            {
+                return;
+            }
+
+            var item = carriedItem;
+            carriedItem = null;
+            item.ReleaseFromCarrier();
+        }
+
+        internal void NotifyItemCarried(InteractableItem item)
+        {
+            if (carriedItem != null && carriedItem != item)
+            {
+                DropCarriedItem();
+            }
+
+            carriedItem = item;
+        }
+
+        internal void NotifyItemReleased(InteractableItem item)
+        {
+            if (carriedItem == item)
+            {
+                carriedItem = null;
+            }
+        }
+
+        private bool IsInteractionSuspended()
+        {
+            if (!isActiveAndEnabled)
+            {
+                return true;
+            }
+
+            if (uiOpen)
+            {
+                return true;
+            }
+
+            return eyeControl != null && eyeControl.IsBlinking;
+        }
+
+        private void HandleInteractionInput()
+        {
+            if (!Input.GetKeyDown(interactKey))
+            {
+                return;
+            }
+
+            if (carriedItem != null)
+            {
+                carriedItem.HandleInteractWhileCarried(this);
+                return;
+            }
+
+            if (currentInteractable == null)
+            {
+                return;
+            }
+
+            if (!currentInteractable.CanInteract(this))
+            {
+                return;
+            }
+
+            currentInteractable.Interact(this);
+        }
+
+        private void UpdateFocus()
+        {
+            var ray = interactionCamera.ViewportPointToRay(new Vector3(0.5f, 0.5f, 0f));
+            if (!Physics.Raycast(ray, out var hit, interactionDistance, interactableLayers, QueryTriggerInteraction.Collide))
+            {
+                ClearFocus();
+                return;
+            }
+
+            var interactable = hit.collider.GetComponentInParent<IInteractable>();
+            if (interactable == null || !interactable.CanInteract(this))
+            {
+                ClearFocus();
+                return;
+            }
+
+            currentInteractable = interactable;
+        }
+
+        private void ClearFocus()
+        {
+            currentInteractable = null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a player interaction controller that raycasts from the active camera, tracks a focused interactable, and invokes it on input
- introduce an interaction framework with an IInteractable interface, interactable pickup implementation, and lock interaction zone support
- expose disabler fragment counters and wire the coordinator to configure the interaction controller on the player prefab

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68e03dbd609c8331ac970c9d08533326