### PR TITLE
Implement crafting station workflow

### DIFF
--- a/Assets/Scripts/Crafting/CraftingStation.cs
+++ b/Assets/Scripts/Crafting/CraftingStation.cs
@@ -1,0 +1,256 @@
+using LSP.Gameplay.Interactions;
+using LSP.Gameplay.UI;
+using UnityEngine;
+
+namespace LSP.Gameplay.Crafting
+{
+    /// <summary>
+    /// Represents a station that repairs the player's disabler when fragments are delivered.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class CraftingStation : MonoBehaviour, IInteractable
+    {
+        [Header("Interaction")]
+        [SerializeField]
+        [Tooltip("Maximum distance the player can stand from the station while crafting.")]
+        private float interactionRadius = 2.5f;
+
+        [SerializeField]
+        [Tooltip("How long the player must hold the interaction key to finish crafting.")]
+        private float craftingDuration = 3f;
+
+        [SerializeField]
+        [Tooltip("Maximum angle in degrees that the player can look away from the station before crafting cancels.")]
+        private float viewAngleTolerance = 20f;
+
+        [Header("Output")]
+        [SerializeField]
+        [Tooltip("Mount where the repaired disabler prefab is spawned upon completion.")]
+        private Transform repairedDisablerMount;
+
+        [SerializeField]
+        [Tooltip("Prefab instantiated when the disabler is repaired.")]
+        private GameObject repairedDisablerPrefab;
+
+        [Header("UI")]
+        [SerializeField]
+        private CraftingUI craftingUi;
+
+        private PlayerInteractionController activePlayer;
+        private Camera activeCamera;
+        private float craftingProgress;
+        private bool isCrafting;
+        private bool hasCrafted;
+
+        private Transform CraftingFocus => repairedDisablerMount != null ? repairedDisablerMount : transform;
+
+        private void Awake()
+        {
+            if (craftingUi == null)
+            {
+                craftingUi = GetComponentInChildren<CraftingUI>();
+            }
+        }
+
+        private void Update()
+        {
+            if (!isCrafting || activePlayer == null)
+            {
+                return;
+            }
+
+            if (!IsPlayerWithinRange(activePlayer) || !IsPlayerLookingAtStation() || !IsPlayerHoldingInteract())
+            {
+                CancelCrafting();
+                return;
+            }
+
+            craftingProgress += Time.deltaTime;
+            float normalised = Mathf.Clamp01(craftingProgress / Mathf.Max(craftingDuration, Mathf.Epsilon));
+            craftingUi?.UpdateProgress(normalised);
+
+            if (craftingProgress >= craftingDuration)
+            {
+                CompleteCrafting();
+            }
+        }
+
+        /// <inheritdoc />
+        public bool CanInteract(PlayerInteractionController caller)
+        {
+            if (!isActiveAndEnabled || hasCrafted)
+            {
+                return false;
+            }
+
+            if (caller == null || caller.DisablerDevice == null)
+            {
+                return false;
+            }
+
+            if (isCrafting && caller != activePlayer)
+            {
+                return false;
+            }
+
+            if (caller.DisablerDevice.CurrentState != DisablerState.Broken)
+            {
+                return false;
+            }
+
+            if (caller.DisablerDevice.CollectedFragments < caller.DisablerDevice.FragmentsRequired)
+            {
+                return false;
+            }
+
+            return IsPlayerWithinRange(caller);
+        }
+
+        /// <inheritdoc />
+        public void Interact(PlayerInteractionController caller)
+        {
+            if (!CanInteract(caller))
+            {
+                return;
+            }
+
+            BeginCrafting(caller);
+        }
+
+        private void BeginCrafting(PlayerInteractionController caller)
+        {
+            activePlayer = caller;
+            activeCamera = caller.GetComponentInChildren<Camera>();
+            if (activeCamera == null)
+            {
+                activeCamera = Camera.main;
+            }
+
+            craftingProgress = 0f;
+            isCrafting = true;
+
+            if (craftingUi != null)
+            {
+                craftingUi.Show(0f);
+            }
+
+            activePlayer.IsUiOpen = true;
+        }
+
+        private void CancelCrafting()
+        {
+            craftingProgress = 0f;
+            isCrafting = false;
+
+            if (craftingUi != null)
+            {
+                craftingUi.Hide();
+            }
+
+            if (activePlayer != null)
+            {
+                activePlayer.IsUiOpen = false;
+            }
+
+            activePlayer = null;
+            activeCamera = null;
+        }
+
+        private void CompleteCrafting()
+        {
+            isCrafting = false;
+
+            craftingUi?.UpdateProgress(1f);
+
+            bool repaired = false;
+            if (activePlayer != null)
+            {
+                var device = activePlayer.DisablerDevice;
+                if (device != null)
+                {
+                    repaired = device.TryRepair();
+                }
+            }
+
+            hasCrafted = repaired;
+
+            if (repaired)
+            {
+                SpawnRepairedDisabler();
+            }
+
+            craftingUi?.Hide();
+
+            if (activePlayer != null)
+            {
+                activePlayer.IsUiOpen = false;
+            }
+
+            activePlayer = null;
+            activeCamera = null;
+            craftingProgress = 0f;
+        }
+
+        private void SpawnRepairedDisabler()
+        {
+            if (repairedDisablerPrefab == null)
+            {
+                return;
+            }
+
+            var mount = CraftingFocus;
+            Instantiate(repairedDisablerPrefab, mount.position, mount.rotation, mount);
+        }
+
+        private bool IsPlayerWithinRange(PlayerInteractionController caller)
+        {
+            if (caller == null)
+            {
+                return false;
+            }
+
+            float distance = Vector3.Distance(caller.transform.position, CraftingFocus.position);
+            return distance <= interactionRadius;
+        }
+
+        private bool IsPlayerHoldingInteract()
+        {
+            if (activePlayer == null)
+            {
+                return false;
+            }
+
+            return Input.GetKey(activePlayer.InteractKey);
+        }
+
+        private bool IsPlayerLookingAtStation()
+        {
+            if (activeCamera == null)
+            {
+                return true;
+            }
+
+            if (viewAngleTolerance <= 0f)
+            {
+                return true;
+            }
+
+            Vector3 directionToFocus = (CraftingFocus.position - activeCamera.transform.position).normalized;
+            if (directionToFocus.sqrMagnitude <= Mathf.Epsilon)
+            {
+                return true;
+            }
+
+            float angle = Vector3.Angle(activeCamera.transform.forward, directionToFocus);
+            return angle <= viewAngleTolerance;
+        }
+
+        private void OnDisable()
+        {
+            if (isCrafting)
+            {
+                CancelCrafting();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/DisablerDevice.cs
+++ b/Assets/Scripts/DisablerDevice.cs
@@ -75,6 +75,7 @@ namespace LSP.Gameplay
                 return false;
             }
 
+            collectedFragments = Mathf.Max(0, collectedFragments - fragmentsRequired);
             CurrentState = DisablerState.Repaired;
             return true;
         }

--- a/Assets/Scripts/PlayerInteractionController.cs
+++ b/Assets/Scripts/PlayerInteractionController.cs
@@ -78,6 +78,11 @@ namespace LSP.Gameplay
         public DisablerDevice DisablerDevice => disablerDevice;
 
         /// <summary>
+        /// Exposes the key used to trigger interactions so other systems can detect holds.
+        /// </summary>
+        public KeyCode InteractKey => interactKey;
+
+        /// <summary>
         /// The interactable item currently being carried by the player, if any.
         /// </summary>
         public InteractableItem CarriedItem => carriedItem;

--- a/Assets/Scripts/UI/CraftingUI.cs
+++ b/Assets/Scripts/UI/CraftingUI.cs
@@ -1,0 +1,78 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace LSP.Gameplay.UI
+{
+    /// <summary>
+    /// Displays crafting progress using a slider inside a world space canvas.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class CraftingUI : MonoBehaviour
+    {
+        [SerializeField]
+        [Tooltip("Canvas that should be enabled while the crafting UI is visible.")]
+        private Canvas rootCanvas;
+
+        [SerializeField]
+        [Tooltip("Slider used to visualise crafting progress.")]
+        private Slider progressSlider;
+
+        private void Awake()
+        {
+            if (rootCanvas == null)
+            {
+                rootCanvas = GetComponentInChildren<Canvas>();
+            }
+
+            if (progressSlider == null)
+            {
+                progressSlider = GetComponentInChildren<Slider>();
+            }
+
+            Hide();
+        }
+
+        /// <summary>
+        /// Makes the crafting UI visible and updates the displayed progress value.
+        /// </summary>
+        /// <param name="normalisedProgress">Progress value in the 0-1 range.</param>
+        public void Show(float normalisedProgress)
+        {
+            SetCanvasVisible(true);
+            UpdateProgress(normalisedProgress);
+        }
+
+        /// <summary>
+        /// Hides the crafting UI.
+        /// </summary>
+        public void Hide()
+        {
+            SetCanvasVisible(false);
+        }
+
+        /// <summary>
+        /// Updates the slider to match the supplied progress value.
+        /// </summary>
+        /// <param name="normalisedProgress">Progress value in the 0-1 range.</param>
+        public void UpdateProgress(float normalisedProgress)
+        {
+            if (progressSlider == null)
+            {
+                return;
+            }
+
+            progressSlider.normalizedValue = Mathf.Clamp01(normalisedProgress);
+        }
+
+        private void SetCanvasVisible(bool visible)
+        {
+            if (rootCanvas != null)
+            {
+                rootCanvas.enabled = visible;
+                return;
+            }
+
+            gameObject.SetActive(visible);
+        }
+    }
+}

--- a/Docs/CoreMechanicsRules.md
+++ b/Docs/CoreMechanicsRules.md
@@ -77,6 +77,14 @@
   - 提供可视化调试（Gizmos）展示各类距离阈值，便于关卡内调校。
   - Inspector 暴露所有阈值、音量曲线及动画持续时间参数。
 
+### 3.4 合成台 Prefab 配置
+- **脚本绑定**：在合成台物体上挂载 `CraftingStation` 组件，并在 Inspector 中设置以下引用：
+  - `Crafting Ui`：指向场景或合成台子节点上的 `CraftingUI` 组件（包含 Slider + Canvas）。
+  - `Repaired Disabler Mount`：合成台上用于生成修复后瘫痪器的空物体。脚本将在此位置生成 Prefab 并设为其子节点，保证朝向一致。
+- **Prefab 引用**：在 `Repaired Disabler Prefab` 字段放入修复后瘫痪器的预制体实例。
+- **场景验证**：确保玩家角色的 `PlayerInteractionController` 已配置 `DisablerDevice` 引用，否则合成条件无法满足。
+- **UI 生命周期**：`CraftingStation` 会在开始合成时调用 `PlayerInteractionController.IsUiOpen = true`。确认 UI 隐藏动画结束时会回调 `Hide()`，避免玩家在 UI 仍显示时重新获得交互输入。
+
 ## 4. 数据与平衡建议
 - 初始建议数值：
   - `dryRate`：每秒 8 单位；`wetRate`：每秒 20 单位；`forcedDuration`：3 秒。


### PR DESCRIPTION
## Summary
- add a crafting station interactable that gates progress on distance, view direction and fragment counts while spawning the repaired disabler
- provide a dedicated crafting progress UI component and expose the interaction key for hold detection
- consume fragments when repairing and document the prefab setup required for the new station

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e059c233748331ab11f3c7543cefad