### PR TITLE
Allow disabler to auto charge after repair

### DIFF
--- a/Assets/Scripts/DisablerDevice.cs
+++ b/Assets/Scripts/DisablerDevice.cs
@@ -24,6 +24,10 @@ namespace LSP.Gameplay
         private float effectRadius = 10f;
 
         [SerializeField]
+        [Tooltip("If enabled, repairing immediately sets the disabler to Charged so it can be used without an extra charging step.")]
+        private bool useImmediatelyWhenRepaired = true;
+
+        [SerializeField]
         private Transform effectOrigin;
 
         private int collectedFragments;
@@ -76,7 +80,16 @@ namespace LSP.Gameplay
             }
 
             collectedFragments = Mathf.Max(0, collectedFragments - fragmentsRequired);
-            CurrentState = DisablerState.Repaired;
+            if (useImmediatelyWhenRepaired)
+            {
+                chargeProgress = chargeDuration;
+                CurrentState = DisablerState.Charged;
+            }
+            else
+            {
+                chargeProgress = 0f;
+                CurrentState = DisablerState.Repaired;
+            }
             return true;
         }
 
@@ -85,6 +98,11 @@ namespace LSP.Gameplay
         /// </summary>
         public bool Charge(float deltaTime)
         {
+            if (CurrentState == DisablerState.Charged)
+            {
+                return true;
+            }
+
             if (CurrentState != DisablerState.Repaired)
             {
                 return false;

--- a/Assets/Scripts/Interactions/InteractableItem.cs
+++ b/Assets/Scripts/Interactions/InteractableItem.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using LSP.Gameplay;
 using LSP.Interactions;
 using UnityEngine;
 
@@ -65,6 +66,7 @@ namespace LSP.Gameplay.Interactions
         private Quaternion originalLocalRotation;
         private Vector3 originalLocalScale;
         private bool isCarried;
+        private DisablerDevice disablerDevice;
 
         /// <summary>
         /// Gets a value indicating whether the item is currently being carried by a player.
@@ -75,6 +77,7 @@ namespace LSP.Gameplay.Interactions
         {
             CacheOriginalTransform();
             ConfigureAutoInteractionColliders(false);
+            disablerDevice = GetComponent<DisablerDevice>();
         }
 
         private void OnDisable()
@@ -95,6 +98,7 @@ namespace LSP.Gameplay.Interactions
             }
 
             UpdateLockZoneTracking();
+            HandleCarriedInput();
         }
 
         /// <inheritdoc />
@@ -200,6 +204,26 @@ namespace LSP.Gameplay.Interactions
             }
 
             Destroy(gameObject);
+        }
+
+        private void HandleCarriedInput()
+        {
+            if (disablerDevice == null || currentCarrier == null)
+            {
+                return;
+            }
+
+            if (currentCarrier.DisablerDevice != disablerDevice)
+            {
+                return;
+            }
+
+            if (!Input.GetKeyDown(currentCarrier.DisablerUseKey))
+            {
+                return;
+            }
+
+            disablerDevice.Use();
         }
 
         private void CacheOriginalTransform()

--- a/Assets/Scripts/PlayerInteractionController.cs
+++ b/Assets/Scripts/PlayerInteractionController.cs
@@ -38,6 +38,11 @@ namespace LSP.Gameplay
         [SerializeField]
         private DisablerDevice disablerDevice;
 
+        [Header("Disabler Usage")]
+        [SerializeField]
+        [Tooltip("Key used to trigger the disabler device while interacting with it.")]
+        private KeyCode disablerUseKey = KeyCode.Q;
+
         private IInteractable currentInteractable;
         private InteractableItem carriedItem;
         private bool uiOpen;
@@ -76,6 +81,11 @@ namespace LSP.Gameplay
         /// Provides the active disabler device so consumable items can update fragment counts.
         /// </summary>
         public DisablerDevice DisablerDevice => disablerDevice;
+
+        /// <summary>
+        /// Gets the key used to activate the disabler device while interacting with it.
+        /// </summary>
+        public KeyCode DisablerUseKey => disablerUseKey;
 
         /// <summary>
         /// Exposes the key used to trigger interactions so other systems can detect holds.


### PR DESCRIPTION
## Summary
- add an inspector toggle that lets the disabler become charged immediately after a successful repair
- ensure TryRepair fills the charge when the toggle is enabled and make Charge() report success once already full

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68e08c13d1e0833184ae5a754d6e429c