### PR TITLE
Initialize disabler devices as ready on spawn

### DIFF
--- a/Assets/Scripts/DisablerDevice.cs
+++ b/Assets/Scripts/DisablerDevice.cs
@@ -28,7 +28,11 @@ namespace LSP.Gameplay
 
         private int collectedFragments;
 
-        public DisablerState CurrentState { get; private set; } = DisablerState.Broken;
+        [SerializeField]
+        [Tooltip("Determines whether the disabler starts ready for use when it spawns.")]
+        private bool startReady = true;
+
+        public DisablerState CurrentState { get; private set; }
 
         public int FragmentsRequired => fragmentsRequired;
 
@@ -40,6 +44,8 @@ namespace LSP.Gameplay
             {
                 effectOrigin = transform;
             }
+
+            CurrentState = startReady ? DisablerState.Ready : DisablerState.Broken;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add an inspector-controlled flag that determines the disabler's starting state
- initialize the disabler as ready on spawn so new devices pass the Use() state check

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1497145ec8331a24500decf97a1fc