### PR TITLE
Add post-encounter scene flow and triggers

### DIFF
--- a/Assets/Scripts/MonsterController.cs
+++ b/Assets/Scripts/MonsterController.cs
@@ -79,6 +79,10 @@ namespace LSP.Gameplay
         [SerializeField]
         private float proximityRestartDistance = 1.5f;
 
+        [Tooltip("Scene loaded after the player is caught. If empty the active scene reloads.")]
+        [SerializeField]
+        private string postEncounterSceneName;
+
         [Tooltip("Fallback speed used when the monster is moved directly because the NavMeshAgent is unavailable.")]
         [SerializeField]
         private float fallbackMoveSpeed = 2.5f;
@@ -759,7 +763,11 @@ namespace LSP.Gameplay
                 return;
             }
 
-            SceneManager.LoadScene(activeScene.name);
+            string sceneToLoad = !string.IsNullOrWhiteSpace(postEncounterSceneName)
+                ? postEncounterSceneName
+                : activeScene.name;
+
+            SceneManager.LoadScene(sceneToLoad);
         }
 
         private bool IsNavMeshAgentAvailable => navMeshAgent != null && navMeshAgent.enabled;

--- a/Assets/Scripts/Triggers/SceneRedirectTrigger.cs
+++ b/Assets/Scripts/Triggers/SceneRedirectTrigger.cs
@@ -1,0 +1,54 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace LSP.Gameplay
+{
+    /// <summary>
+    /// Loads a target scene when the player enters the trigger.
+    /// </summary>
+    [RequireComponent(typeof(Collider))]
+    public class SceneRedirectTrigger : MonoBehaviour
+    {
+        [SerializeField]
+        [Tooltip("Scene that will be loaded when the player enters the trigger.")]
+        private string targetSceneName;
+
+        [SerializeField]
+        [Tooltip("Name of the tag that identifies the player.")]
+        private string playerTag = "Player";
+
+        [SerializeField]
+        [Tooltip("If true, the trigger can only be used once.")]
+        private bool triggerOnce = true;
+
+        private bool hasTriggered;
+
+        private void Reset()
+        {
+            var collider = GetComponent<Collider>();
+            collider.isTrigger = true;
+        }
+
+        private void OnTriggerEnter(Collider other)
+        {
+            if (triggerOnce && hasTriggered)
+            {
+                return;
+            }
+
+            if (!other.CompareTag(playerTag))
+            {
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(targetSceneName))
+            {
+                Debug.LogWarning("SceneRedirectTrigger has no target scene assigned.");
+                return;
+            }
+
+            hasTriggered = true;
+            SceneManager.LoadScene(targetSceneName);
+        }
+    }
+}

--- a/Assets/Scripts/Triggers/WorldAbnormalTrigger.cs
+++ b/Assets/Scripts/Triggers/WorldAbnormalTrigger.cs
@@ -1,0 +1,63 @@
+using UnityEngine;
+
+namespace LSP.Gameplay
+{
+    /// <summary>
+    /// Sets the world abnormal state when the player enters the trigger.
+    /// The GameManager reference can be assigned directly from the inspector.
+    /// </summary>
+    [RequireComponent(typeof(Collider))]
+    public class WorldAbnormalTrigger : MonoBehaviour
+    {
+        [SerializeField]
+        [Tooltip("Optional GameManager override. If not set, the singleton instance is used.")]
+        private GameManager gameManager;
+
+        [SerializeField]
+        [Tooltip("Name of the player tag allowed to trigger the abnormal state change.")]
+        private string playerTag = "Player";
+
+        [SerializeField]
+        [Tooltip("World abnormal state value applied when the player enters the trigger.")]
+        private bool abnormalState = true;
+
+        [SerializeField]
+        [Tooltip("If true, the trigger only fires once and then becomes inactive.")]
+        private bool triggerOnce = true;
+
+        private bool hasTriggered;
+
+        private void Reset()
+        {
+            var collider = GetComponent<Collider>();
+            collider.isTrigger = true;
+        }
+
+        private void OnTriggerEnter(Collider other)
+        {
+            if (triggerOnce && hasTriggered)
+            {
+                return;
+            }
+
+            if (!other.CompareTag(playerTag))
+            {
+                return;
+            }
+
+            if (gameManager == null)
+            {
+                gameManager = GameManager.Instance;
+            }
+
+            if (gameManager == null)
+            {
+                Debug.LogWarning("WorldAbnormalTrigger could not find a GameManager to update.");
+                return;
+            }
+
+            gameManager.SetWorldAbnormalState(abnormalState);
+            hasTriggered = true;
+        }
+    }
+}

--- a/Assets/Scripts/UI/RestartMenuController.cs
+++ b/Assets/Scripts/UI/RestartMenuController.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace LSP.Gameplay
+{
+    /// <summary>
+    /// Handles the logic for the restart menu that appears after the player dies or reaches safety.
+    /// </summary>
+    public class RestartMenuController : MonoBehaviour
+    {
+        [SerializeField]
+        [Tooltip("Scene that will be loaded when the player chooses to replay.")]
+        private string gameplaySceneName;
+
+        [SerializeField]
+        [Tooltip("Optional cursor visibility override when the menu loads.")]
+        private bool showCursor = true;
+
+        [SerializeField]
+        [Tooltip("Whether to unlock the cursor when the menu loads.")]
+        private bool unlockCursor = true;
+
+        private void Awake()
+        {
+            if (showCursor)
+            {
+                Cursor.visible = true;
+            }
+
+            if (unlockCursor)
+            {
+                Cursor.lockState = CursorLockMode.None;
+            }
+        }
+
+        public void Replay()
+        {
+            if (string.IsNullOrWhiteSpace(gameplaySceneName))
+            {
+                Debug.LogWarning("RestartMenuController has no gameplay scene assigned to reload.");
+                return;
+            }
+
+            SceneManager.LoadScene(gameplaySceneName);
+        }
+
+        public void Quit()
+        {
+    #if UNITY_EDITOR
+            UnityEditor.EditorApplication.isPlaying = false;
+    #else
+            Application.Quit();
+    #endif
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable scene transition when the monster catches the player
- create triggers for toggling the abnormal world state and redirecting to the restart menu
- implement restart menu controller to replay the game or quit the application

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e670f2fce08331a5bbaa5b1a1d37ad