### PR TITLE
Refine low wetness warning into configurable flicker

### DIFF
--- a/Assets/Scripts/PlayerCameraBinder.cs
+++ b/Assets/Scripts/PlayerCameraBinder.cs
@@ -39,6 +39,19 @@ namespace LSP.Gameplay
         [SerializeField]
         private float forcedFadeOutDuration = 0.25f;
 
+        [Header("Warning Blink Flashing")]
+        [Tooltip("Overrides the number of warning flashes if no eye controller is assigned.")]
+        [SerializeField]
+        private int defaultWarningFlashCount = 3;
+
+        [Tooltip("Seconds used to darken the overlay during each warning flash when the eye controller is missing.")]
+        [SerializeField]
+        private float defaultWarningDarkenDuration = 0.08f;
+
+        [Tooltip("Seconds used to lighten the overlay during each warning flash when the eye controller is missing.")]
+        [SerializeField]
+        private float defaultWarningLightenDuration = 0.08f;
+
         private Camera attachedCamera;
         private Coroutine blinkRoutine;
 
@@ -152,34 +165,77 @@ namespace LSP.Gameplay
 
         private System.Collections.IEnumerator BlinkRoutine(PlayerEyeControl.BlinkType blinkType, float duration)
         {
-            float fadeIn = blinkType == PlayerEyeControl.BlinkType.Forced ? forcedFadeInDuration : manualFadeInDuration;
-            float fadeOut = blinkType == PlayerEyeControl.BlinkType.Forced ? forcedFadeOutDuration : manualFadeOutDuration;
-
-            fadeIn = Mathf.Max(0f, fadeIn);
-            fadeOut = Mathf.Max(0f, fadeOut);
-
-            float fadeSum = fadeIn + fadeOut;
-            if (fadeSum > duration && fadeSum > 0f)
+            if (blinkType == PlayerEyeControl.BlinkType.Warning)
             {
-                float scale = duration / fadeSum;
-                fadeIn *= scale;
-                fadeOut *= scale;
-                fadeSum = fadeIn + fadeOut;
+                yield return WarningBlinkRoutine();
             }
-
-            float holdDuration = Mathf.Max(0f, duration - fadeSum);
-
-            yield return FadeOverlay(1f, fadeIn);
-
-            if (holdDuration > 0f)
+            else
             {
-                yield return new WaitForSeconds(holdDuration);
-            }
+                float fadeIn;
+                float fadeOut;
 
-            yield return FadeOverlay(0f, fadeOut);
+                switch (blinkType)
+                {
+                    case PlayerEyeControl.BlinkType.Forced:
+                        fadeIn = forcedFadeInDuration;
+                        fadeOut = forcedFadeOutDuration;
+                        break;
+                    default:
+                        fadeIn = manualFadeInDuration;
+                        fadeOut = manualFadeOutDuration;
+                        break;
+                }
+
+                fadeIn = Mathf.Max(0f, fadeIn);
+                fadeOut = Mathf.Max(0f, fadeOut);
+
+                float fadeSum = fadeIn + fadeOut;
+                if (fadeSum > duration && fadeSum > 0f)
+                {
+                    float scale = duration / fadeSum;
+                    fadeIn *= scale;
+                    fadeOut *= scale;
+                    fadeSum = fadeIn + fadeOut;
+                }
+
+                float holdDuration = Mathf.Max(0f, duration - fadeSum);
+
+                yield return FadeOverlay(1f, fadeIn);
+
+                if (holdDuration > 0f)
+                {
+                    yield return new WaitForSeconds(holdDuration);
+                }
+
+                yield return FadeOverlay(0f, fadeOut);
+            }
 
             blinkRoutine = null;
             UpdateOverlayImmediate();
+        }
+
+        private System.Collections.IEnumerator WarningBlinkRoutine()
+        {
+            int flashes = defaultWarningFlashCount;
+            float darken = defaultWarningDarkenDuration;
+            float lighten = defaultWarningLightenDuration;
+
+            if (eyeControl != null)
+            {
+                flashes = eyeControl.WarningBlinkFlashCount;
+                darken = eyeControl.WarningBlinkDarkenDuration;
+                lighten = eyeControl.WarningBlinkLightenDuration;
+            }
+
+            flashes = Mathf.Max(1, flashes);
+            darken = Mathf.Max(0f, darken);
+            lighten = Mathf.Max(0f, lighten);
+
+            for (int i = 0; i < flashes; i++)
+            {
+                yield return FadeOverlay(1f, darken);
+                yield return FadeOverlay(0f, lighten);
+            }
         }
 
         private System.Collections.IEnumerator FadeOverlay(float targetAlpha, float duration)

--- a/Assets/Scripts/PlayerEyeControl.cs
+++ b/Assets/Scripts/PlayerEyeControl.cs
@@ -11,7 +11,8 @@ namespace LSP.Gameplay
         public enum BlinkType
         {
             Manual,
-            Forced
+            Forced,
+            Warning
         }
 
         [Header("Wetness Settings")]
@@ -42,9 +43,33 @@ namespace LSP.Gameplay
         [SerializeField]
         private int manualBlinkMouseButton = 0;
 
+        [Header("Low Wetness Warning")]
+        [Tooltip("Fraction of the maximum wetness that triggers the warning blink behaviour.")]
+        [Range(0f, 1f)]
+        [SerializeField]
+        private float warningWetnessThresholdFraction = 0.25f;
+
+        [Tooltip("How many quick flashes play while wetness is low.")]
+        [SerializeField]
+        private int warningBlinkFlashCount = 3;
+
+        [Tooltip("Seconds spent darkening the screen for each low wetness warning flash.")]
+        [SerializeField]
+        private float warningBlinkDarkenDuration = 0.08f;
+
+        [Tooltip("Seconds spent brightening the screen after each warning flash.")]
+        [SerializeField]
+        private float warningBlinkLightenDuration = 0.08f;
+
+        [Tooltip("Delay between warning blink sequences while the wetness remains below the threshold.")]
+        [SerializeField]
+        private float warningBlinkCooldown = 4f;
+
         private float currentWetness;
         private float forcedBlinkTimer;
         private float manualBlinkTimer;
+        private float warningBlinkTimer;
+        private float warningBlinkCooldownTimer;
         private bool eyesOpen = true;
 
         public float CurrentWetness => currentWetness;
@@ -92,7 +117,26 @@ namespace LSP.Gameplay
         public bool EyesOpen => eyesOpen;
         public bool IsForcedClosing => forcedBlinkTimer > 0f;
         public bool IsManualBlinking => manualBlinkTimer > 0f;
-        public bool IsBlinking => IsForcedClosing || IsManualBlinking;
+        public bool IsWarningBlinking => warningBlinkTimer > 0f;
+        public bool IsBlinking => IsForcedClosing || IsManualBlinking || IsWarningBlinking;
+
+        public int WarningBlinkFlashCount
+        {
+            get => Mathf.Max(1, warningBlinkFlashCount);
+            set => warningBlinkFlashCount = Mathf.Max(1, value);
+        }
+
+        public float WarningBlinkDarkenDuration
+        {
+            get => Mathf.Max(0f, warningBlinkDarkenDuration);
+            set => warningBlinkDarkenDuration = Mathf.Max(0f, value);
+        }
+
+        public float WarningBlinkLightenDuration
+        {
+            get => Mathf.Max(0f, warningBlinkLightenDuration);
+            set => warningBlinkLightenDuration = Mathf.Max(0f, value);
+        }
 
         public event Action EyesForcedClosed;
         public event Action EyesForcedOpened;
@@ -111,6 +155,7 @@ namespace LSP.Gameplay
             UpdateBlinkTimers(deltaTime);
             HandleInput();
             UpdateWetness(deltaTime);
+            UpdateWarningBlink(deltaTime);
         }
 
         private void HandleInput()
@@ -152,6 +197,51 @@ namespace LSP.Gameplay
             }
         }
 
+        private void UpdateWarningBlink(float deltaTime)
+        {
+            if (warningBlinkCooldownTimer > 0f)
+            {
+                warningBlinkCooldownTimer -= deltaTime;
+                if (warningBlinkCooldownTimer < 0f)
+                {
+                    warningBlinkCooldownTimer = 0f;
+                }
+            }
+
+            if (warningBlinkTimer > 0f)
+            {
+                warningBlinkTimer -= deltaTime;
+                if (warningBlinkTimer <= 0f)
+                {
+                    warningBlinkTimer = 0f;
+                    EndWarningBlink();
+                }
+
+                return;
+            }
+
+            if (IsForcedClosing || IsManualBlinking)
+            {
+                CancelWarningBlink(false);
+                return;
+            }
+
+            bool lowWetness = maximumWetness > Mathf.Epsilon && currentWetness <= maximumWetness * warningWetnessThresholdFraction;
+            if (!lowWetness)
+            {
+                CancelWarningBlink(true);
+                warningBlinkCooldownTimer = 0f;
+                return;
+            }
+
+            if (warningBlinkCooldownTimer > 0f)
+            {
+                return;
+            }
+
+            BeginWarningBlink();
+        }
+
         private void UpdateWetness(float deltaTime)
         {
             if (EyesOpen)
@@ -173,6 +263,8 @@ namespace LSP.Gameplay
 
         private void BeginManualBlink()
         {
+            CancelWarningBlink(false);
+            warningBlinkCooldownTimer = warningBlinkCooldown;
             manualBlinkTimer = manualBlinkDuration;
             eyesOpen = false;
             currentWetness = Mathf.Clamp(currentWetness + restoreWetnessPerManualBlink, 0f, maximumWetness);
@@ -181,7 +273,7 @@ namespace LSP.Gameplay
 
         private void EndManualBlink()
         {
-            eyesOpen = !IsForcedClosing;
+            eyesOpen = !IsForcedClosing && !IsWarningBlinking;
             BlinkEnded?.Invoke(BlinkType.Manual);
         }
 
@@ -192,6 +284,8 @@ namespace LSP.Gameplay
                 return;
             }
 
+            CancelWarningBlink(false);
+            warningBlinkCooldownTimer = warningBlinkCooldown;
             forcedBlinkTimer = forcedBlinkDuration;
             eyesOpen = false;
             EyesForcedClosed?.Invoke();
@@ -200,7 +294,7 @@ namespace LSP.Gameplay
 
         private void EndForcedBlink()
         {
-            if (!IsManualBlinking)
+            if (!IsManualBlinking && !IsWarningBlinking)
             {
                 eyesOpen = true;
                 BlinkEnded?.Invoke(BlinkType.Forced);
@@ -213,15 +307,61 @@ namespace LSP.Gameplay
             EyesForcedOpened?.Invoke();
         }
 
+        private void BeginWarningBlink()
+        {
+            float duration = GetWarningBlinkDuration();
+            warningBlinkTimer = duration;
+            BlinkStarted?.Invoke(BlinkType.Warning, duration);
+
+            if (warningBlinkTimer <= 0f)
+            {
+                EndWarningBlink();
+            }
+        }
+
+        private void EndWarningBlink()
+        {
+            warningBlinkCooldownTimer = warningBlinkCooldown;
+
+            BlinkEnded?.Invoke(BlinkType.Warning);
+        }
+
+        private void CancelWarningBlink(bool notify)
+        {
+            if (warningBlinkTimer <= 0f)
+            {
+                return;
+            }
+
+            warningBlinkTimer = 0f;
+
+            if (notify)
+            {
+                BlinkEnded?.Invoke(BlinkType.Warning);
+            }
+        }
+
         /// <summary>
         /// Instantly restores the wetness resource. Useful when restarting a level.
         /// </summary>
         public void ResetWetness()
         {
+            CancelWarningBlink(true);
             currentWetness = maximumWetness;
             forcedBlinkTimer = 0f;
             manualBlinkTimer = 0f;
+            warningBlinkTimer = 0f;
+            warningBlinkCooldownTimer = 0f;
             eyesOpen = true;
+        }
+
+        private float GetWarningBlinkDuration()
+        {
+            int flashes = Mathf.Max(1, warningBlinkFlashCount);
+            float darken = Mathf.Max(0f, warningBlinkDarkenDuration);
+            float lighten = Mathf.Max(0f, warningBlinkLightenDuration);
+
+            return flashes * (darken + lighten);
         }
 
 #if UNITY_EDITOR
@@ -233,6 +373,11 @@ namespace LSP.Gameplay
             restoreWetnessPerManualBlink = Mathf.Max(0f, restoreWetnessPerManualBlink);
             forcedBlinkDuration = Mathf.Max(0f, forcedBlinkDuration);
             manualBlinkDuration = Mathf.Max(0f, manualBlinkDuration);
+            warningWetnessThresholdFraction = Mathf.Clamp01(warningWetnessThresholdFraction);
+            warningBlinkFlashCount = Mathf.Max(1, warningBlinkFlashCount);
+            warningBlinkDarkenDuration = Mathf.Max(0f, warningBlinkDarkenDuration);
+            warningBlinkLightenDuration = Mathf.Max(0f, warningBlinkLightenDuration);
+            warningBlinkCooldown = Mathf.Max(0f, warningBlinkCooldown);
         }
 #endif
     }


### PR DESCRIPTION
## Summary
- change the low-wetness warning to play a configurable flicker effect without closing the player's eyes or altering wetness
- expose flash count and darken/lighten timing on the eye controller and drive the overlay animation through the camera binder with safe defaults

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68f98ae13cdc833196df2e1afa76e7de