### PR TITLE
Add detection howl trigger for monster

### DIFF
--- a/Assets/Scripts/MonsterController.cs
+++ b/Assets/Scripts/MonsterController.cs
@@ -74,6 +74,14 @@ namespace LSP.Gameplay
         [SerializeField]
         private AudioSource footstepAudioSource;
 
+        [Tooltip("Audio source used to play the monster's howl when it detects the player.")]
+        [SerializeField]
+        private AudioSource detectionAudioSource;
+
+        [Tooltip("Audio clip played when the monster first spots the player.")]
+        [SerializeField]
+        private AudioClip detectionHowlClip;
+
         [Tooltip("Maximum volume applied to the footstep audio when the monster is next to the player.")]
         [Range(0f, 1f)]
         [SerializeField]
@@ -181,6 +189,13 @@ namespace LSP.Gameplay
                 footstepAudioSource.loop = true;
                 footstepAudioSource.playOnAwake = false;
                 footstepAudioSource.Stop();
+            }
+
+            if (detectionAudioSource != null)
+            {
+                detectionAudioSource.loop = false;
+                detectionAudioSource.playOnAwake = false;
+                detectionAudioSource.Stop();
             }
         }
 
@@ -311,7 +326,30 @@ namespace LSP.Gameplay
                 {
                     ResumeNavMeshAgent();
                     ApplyAnimatorMovementState();
+                    PlayDetectionHowl();
                 }
+            }
+        }
+
+        private void PlayDetectionHowl()
+        {
+            if (detectionAudioSource != null)
+            {
+                if (detectionHowlClip != null)
+                {
+                    detectionAudioSource.PlayOneShot(detectionHowlClip);
+                }
+                else
+                {
+                    detectionAudioSource.Play();
+                }
+
+                return;
+            }
+
+            if (detectionHowlClip != null)
+            {
+                AudioSource.PlayClipAtPoint(detectionHowlClip, transform.position);
             }
         }
 


### PR DESCRIPTION
## Summary
- add serialized fields so a howl source and clip can be assigned in the inspector
- play the howl once whenever the monster begins chasing the player

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f9aa664ea48331a0b88054b88ea8f8