### PR TITLE
Add gravity switch puzzle components

### DIFF
--- a/Assets/Scripts/Interactions/GravitySwitch.cs
+++ b/Assets/Scripts/Interactions/GravitySwitch.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using LSP.Gameplay;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace LSP.Gameplay.Interactions
+{
+    /// <summary>
+    /// Represents a floor switch that reacts to the player or monster standing on it.
+    /// The switch raises events when pressed or released and exposes its state to
+    /// other systems such as chained logic gates.
+    /// </summary>
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(Collider))]
+    public class GravitySwitch : MonoBehaviour
+    {
+        [Serializable]
+        public class SwitchStateEvent : UnityEvent<bool>
+        {
+        }
+
+        [Header("Events")]
+        [SerializeField]
+        [Tooltip("Invoked whenever the pressed state changes.")]
+        private SwitchStateEvent stateChanged;
+
+        [SerializeField]
+        [Tooltip("Raised when the switch is pressed.")]
+        private UnityEvent onPressed;
+
+        [SerializeField]
+        [Tooltip("Raised when the switch is released.")]
+        private UnityEvent onReleased;
+
+        private readonly HashSet<Collider> activeColliders = new HashSet<Collider>();
+
+        /// <summary>
+        /// Current pressed state of the switch.
+        /// </summary>
+        public bool IsPressed { get; private set; }
+
+        /// <summary>
+        /// Event fired whenever <see cref="IsPressed"/> changes.
+        /// </summary>
+        public event Action<GravitySwitch> PressedStateChanged;
+
+        private void Reset()
+        {
+            var triggerCollider = GetComponent<Collider>();
+            triggerCollider.isTrigger = true;
+        }
+
+        private void OnTriggerEnter(Collider other)
+        {
+            if (!IsValidActivator(other))
+            {
+                return;
+            }
+
+            if (activeColliders.Add(other))
+            {
+                SetPressed(true);
+            }
+        }
+
+        private void OnTriggerExit(Collider other)
+        {
+            if (!activeColliders.Remove(other))
+            {
+                return;
+            }
+
+            if (activeColliders.Count == 0)
+            {
+                SetPressed(false);
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (activeColliders.Count == 0 && !IsPressed)
+            {
+                return;
+            }
+
+            activeColliders.Clear();
+            SetPressed(false);
+        }
+
+        /// <summary>
+        /// Forces the pressed state without requiring a collider.
+        /// </summary>
+        public void ForceSetPressed(bool pressed)
+        {
+            activeColliders.Clear();
+            SetPressed(pressed);
+        }
+
+        private bool IsValidActivator(Collider collider)
+        {
+            if (collider == null)
+            {
+                return false;
+            }
+
+            if (collider.GetComponentInParent<PlayerStateController>() != null)
+            {
+                return true;
+            }
+
+            if (collider.GetComponentInParent<MonsterController>() != null)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private void SetPressed(bool pressed)
+        {
+            if (IsPressed == pressed)
+            {
+                return;
+            }
+
+            IsPressed = pressed;
+            stateChanged?.Invoke(IsPressed);
+
+            if (IsPressed)
+            {
+                onPressed?.Invoke();
+            }
+            else
+            {
+                onReleased?.Invoke();
+            }
+
+            PressedStateChanged?.Invoke(this);
+        }
+    }
+}

--- a/Assets/Scripts/Interactions/GravitySwitchGroup.cs
+++ b/Assets/Scripts/Interactions/GravitySwitchGroup.cs
@@ -1,0 +1,140 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace LSP.Gameplay.Interactions
+{
+    /// <summary>
+    /// Aggregates multiple <see cref="GravitySwitch"/> instances and raises events when
+    /// a configured number of them are pressed simultaneously. This allows puzzles to
+    /// require players and monsters to cooperate across chained switches.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class GravitySwitchGroup : MonoBehaviour
+    {
+        [System.Serializable]
+        public class GroupStateEvent : UnityEvent<bool>
+        {
+        }
+
+        [Tooltip("Switches monitored by this group. Duplicates are ignored at runtime.")]
+        [SerializeField]
+        private GravitySwitch[] switches;
+
+        [Tooltip("How many switches must be pressed for the group to activate. If set to 0 the group requires all configured switches.")]
+        [Min(0)]
+        [SerializeField]
+        private int requiredActiveSwitches;
+
+        [Header("Events")]
+        [SerializeField]
+        private GroupStateEvent stateChanged;
+
+        [SerializeField]
+        private UnityEvent onActivated;
+
+        [SerializeField]
+        private UnityEvent onDeactivated;
+
+        private readonly List<GravitySwitch> uniqueSwitches = new List<GravitySwitch>();
+
+        /// <summary>
+        /// True when the group has reached the required active count.
+        /// </summary>
+        public bool IsActive { get; private set; }
+
+        private void OnEnable()
+        {
+            RefreshSubscriptions();
+            EvaluateState();
+        }
+
+        private void OnDisable()
+        {
+            ClearSubscriptions();
+            uniqueSwitches.Clear();
+        }
+
+        private void RefreshSubscriptions()
+        {
+            ClearSubscriptions();
+            uniqueSwitches.Clear();
+
+            if (switches == null)
+            {
+                return;
+            }
+
+            foreach (var gravitySwitch in switches)
+            {
+                if (gravitySwitch == null || uniqueSwitches.Contains(gravitySwitch))
+                {
+                    continue;
+                }
+
+                uniqueSwitches.Add(gravitySwitch);
+                gravitySwitch.PressedStateChanged += HandleSwitchStateChanged;
+            }
+        }
+
+        private void ClearSubscriptions()
+        {
+            foreach (var gravitySwitch in uniqueSwitches)
+            {
+                if (gravitySwitch != null)
+                {
+                    gravitySwitch.PressedStateChanged -= HandleSwitchStateChanged;
+                }
+            }
+        }
+
+        private void HandleSwitchStateChanged(GravitySwitch _)
+        {
+            EvaluateState();
+        }
+
+        private void EvaluateState()
+        {
+            if (uniqueSwitches.Count == 0)
+            {
+                SetActive(false);
+                return;
+            }
+
+            var target = requiredActiveSwitches <= 0
+                ? uniqueSwitches.Count
+                : Mathf.Min(requiredActiveSwitches, uniqueSwitches.Count);
+
+            var activeCount = 0;
+            for (var i = 0; i < uniqueSwitches.Count; i++)
+            {
+                if (uniqueSwitches[i] != null && uniqueSwitches[i].IsPressed)
+                {
+                    activeCount++;
+                }
+            }
+
+            SetActive(activeCount >= target);
+        }
+
+        private void SetActive(bool active)
+        {
+            if (IsActive == active)
+            {
+                return;
+            }
+
+            IsActive = active;
+            stateChanged?.Invoke(IsActive);
+
+            if (IsActive)
+            {
+                onActivated?.Invoke();
+            }
+            else
+            {
+                onDeactivated?.Invoke();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable GravitySwitch MonoBehaviour that detects players and monsters standing on it and raises UnityEvents
- add a GravitySwitchGroup component to require multiple switches to activate chained puzzle logic

## Testing
- not run (Unity project code only)


------
https://chatgpt.com/codex/tasks/task_e_68fe321b7f1c8331bb4155097520753e