### PR TITLE
Ensure gravity switches behave as pressure plates

### DIFF
--- a/Assets/Scripts/Interactions/GravitySwitch.cs
+++ b/Assets/Scripts/Interactions/GravitySwitch.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using LSP.Gameplay;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace LSP.Gameplay.Interactions
+{
+    /// <summary>
+    /// Represents a floor switch that reacts to the player or monster standing on it.
+    /// The switch raises events when pressed or released and exposes its state to
+    /// other systems such as chained logic gates.
+    /// </summary>
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(Collider))]
+    [AddComponentMenu("LSP/Interactions/Gravity Switch")]
+    public class GravitySwitch : MonoBehaviour
+    {
+        [Serializable]
+        public class SwitchStateEvent : UnityEvent<bool>
+        {
+        }
+
+        [Header("Events")]
+        [SerializeField]
+        [Tooltip("Invoked whenever the pressed state changes.")]
+        private SwitchStateEvent stateChanged = new SwitchStateEvent();
+
+        [SerializeField]
+        [Tooltip("Raised when the switch is pressed.")]
+        private UnityEvent onPressed = new UnityEvent();
+
+        [SerializeField]
+        [Tooltip("Raised when the switch is released.")]
+        private UnityEvent onReleased = new UnityEvent();
+
+        private readonly HashSet<Collider> activeColliders = new HashSet<Collider>();
+
+        /// <summary>
+        /// Current pressed state of the switch.
+        /// </summary>
+        public bool IsPressed { get; private set; }
+
+        /// <summary>
+        /// Event fired whenever <see cref="IsPressed"/> changes.
+        /// </summary>
+        public event Action<GravitySwitch> PressedStateChanged;
+
+        /// <summary>
+        /// UnityEvent exposed for designers to respond to pressed state changes.
+        /// </summary>
+        public SwitchStateEvent StateChangedEvent => stateChanged;
+
+        /// <summary>
+        /// UnityEvent exposed for designers to respond when the switch is pressed.
+        /// </summary>
+        public UnityEvent OnPressedEvent => onPressed;
+
+        /// <summary>
+        /// UnityEvent exposed for designers to respond when the switch is released.
+        /// </summary>
+        public UnityEvent OnReleasedEvent => onReleased;
+
+        private void Reset()
+        {
+            var triggerCollider = GetComponent<Collider>();
+            triggerCollider.isTrigger = true;
+        }
+
+        private void OnValidate()
+        {
+            var triggerCollider = GetComponent<Collider>();
+            if (triggerCollider != null && !triggerCollider.isTrigger)
+            {
+                triggerCollider.isTrigger = true;
+            }
+        }
+
+        private void FixedUpdate()
+        {
+            if (activeColliders.Count == 0)
+            {
+                return;
+            }
+
+            if (RemoveInvalidColliders() && activeColliders.Count == 0)
+            {
+                SetPressed(false);
+            }
+        }
+
+        private void OnTriggerEnter(Collider other)
+        {
+            if (!IsValidActivator(other))
+            {
+                return;
+            }
+
+            if (activeColliders.Add(other))
+            {
+                SetPressed(true);
+            }
+        }
+
+        private void OnTriggerExit(Collider other)
+        {
+            if (!activeColliders.Remove(other))
+            {
+                return;
+            }
+
+            if (activeColliders.Count == 0)
+            {
+                SetPressed(false);
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (activeColliders.Count == 0 && !IsPressed)
+            {
+                return;
+            }
+
+            activeColliders.Clear();
+            SetPressed(false);
+        }
+
+        /// <summary>
+        /// Forces the pressed state without requiring a collider.
+        /// </summary>
+        public void ForceSetPressed(bool pressed)
+        {
+            activeColliders.Clear();
+            SetPressed(pressed);
+        }
+
+        private bool RemoveInvalidColliders()
+        {
+            var removedAny = false;
+
+            activeColliders.RemoveWhere(collider =>
+            {
+                if (collider != null && collider.enabled && collider.gameObject.activeInHierarchy)
+                {
+                    return false;
+                }
+
+                removedAny = true;
+                return true;
+            });
+
+            return removedAny;
+        }
+
+        private bool IsValidActivator(Collider collider)
+        {
+            if (collider == null)
+            {
+                return false;
+            }
+
+            if (collider.GetComponentInParent<PlayerStateController>() != null)
+            {
+                return true;
+            }
+
+            if (collider.GetComponentInParent<MonsterController>() != null)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private void SetPressed(bool pressed)
+        {
+            if (IsPressed == pressed)
+            {
+                return;
+            }
+
+            IsPressed = pressed;
+            stateChanged?.Invoke(IsPressed);
+
+            if (IsPressed)
+            {
+                onPressed?.Invoke();
+            }
+            else
+            {
+                onReleased?.Invoke();
+            }
+
+            PressedStateChanged?.Invoke(this);
+        }
+    }
+}

--- a/Assets/Scripts/Interactions/GravitySwitchGroup.cs
+++ b/Assets/Scripts/Interactions/GravitySwitchGroup.cs
@@ -1,0 +1,156 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace LSP.Gameplay.Interactions
+{
+    /// <summary>
+    /// Aggregates multiple <see cref="GravitySwitch"/> instances and raises events when
+    /// a configured number of them are pressed simultaneously. This allows puzzles to
+    /// require players and monsters to cooperate across chained switches.
+    /// </summary>
+    [DisallowMultipleComponent]
+    [AddComponentMenu("LSP/Interactions/Gravity Switch Group")]
+    public class GravitySwitchGroup : MonoBehaviour
+    {
+        [System.Serializable]
+        public class GroupStateEvent : UnityEvent<bool>
+        {
+        }
+
+        [Tooltip("Switches monitored by this group. Duplicates are ignored at runtime.")]
+        [SerializeField]
+        private GravitySwitch[] switches;
+
+        [Tooltip("How many switches must be pressed for the group to activate. If set to 0 the group requires all configured switches.")]
+        [Min(0)]
+        [SerializeField]
+        private int requiredActiveSwitches;
+
+        [Header("Events")]
+        [SerializeField]
+        private GroupStateEvent stateChanged = new GroupStateEvent();
+
+        [SerializeField]
+        private UnityEvent onActivated = new UnityEvent();
+
+        [SerializeField]
+        private UnityEvent onDeactivated = new UnityEvent();
+
+        private readonly List<GravitySwitch> uniqueSwitches = new List<GravitySwitch>();
+
+        /// <summary>
+        /// True when the group has reached the required active count.
+        /// </summary>
+        public bool IsActive { get; private set; }
+
+        /// <summary>
+        /// UnityEvent exposed for designers to respond when the group activation state changes.
+        /// </summary>
+        public GroupStateEvent StateChangedEvent => stateChanged;
+
+        /// <summary>
+        /// UnityEvent exposed for designers to respond when the group activates.
+        /// </summary>
+        public UnityEvent OnActivatedEvent => onActivated;
+
+        /// <summary>
+        /// UnityEvent exposed for designers to respond when the group deactivates.
+        /// </summary>
+        public UnityEvent OnDeactivatedEvent => onDeactivated;
+
+        private void OnEnable()
+        {
+            RefreshSubscriptions();
+            EvaluateState();
+        }
+
+        private void OnDisable()
+        {
+            ClearSubscriptions();
+            uniqueSwitches.Clear();
+        }
+
+        private void RefreshSubscriptions()
+        {
+            ClearSubscriptions();
+            uniqueSwitches.Clear();
+
+            if (switches == null)
+            {
+                return;
+            }
+
+            foreach (var gravitySwitch in switches)
+            {
+                if (gravitySwitch == null || uniqueSwitches.Contains(gravitySwitch))
+                {
+                    continue;
+                }
+
+                uniqueSwitches.Add(gravitySwitch);
+                gravitySwitch.PressedStateChanged += HandleSwitchStateChanged;
+            }
+        }
+
+        private void ClearSubscriptions()
+        {
+            foreach (var gravitySwitch in uniqueSwitches)
+            {
+                if (gravitySwitch != null)
+                {
+                    gravitySwitch.PressedStateChanged -= HandleSwitchStateChanged;
+                }
+            }
+        }
+
+        private void HandleSwitchStateChanged(GravitySwitch _)
+        {
+            EvaluateState();
+        }
+
+        private void EvaluateState()
+        {
+            if (uniqueSwitches.Count == 0)
+            {
+                SetActive(false);
+                return;
+            }
+
+            var target = requiredActiveSwitches <= 0
+                ? uniqueSwitches.Count
+                : Mathf.Min(requiredActiveSwitches, uniqueSwitches.Count);
+
+            var activeCount = 0;
+            for (var i = 0; i < uniqueSwitches.Count; i++)
+            {
+                if (uniqueSwitches[i] != null && uniqueSwitches[i].IsPressed)
+                {
+                    activeCount++;
+                }
+            }
+
+            SetActive(activeCount >= target);
+        }
+
+        private void SetActive(bool active)
+        {
+            if (IsActive == active)
+            {
+                return;
+            }
+
+            IsActive = active;
+            stateChanged?.Invoke(IsActive);
+
+            if (IsActive)
+            {
+                onActivated?.Invoke();
+            }
+            else
+            {
+                onDeactivated?.Invoke();
+            }
+        }
+    }
+}

--- a/Docs/GravitySwitchUsage.md
+++ b/Docs/GravitySwitchUsage.md
@@ -1,0 +1,74 @@
+# 重力机关使用指南
+
+本文档介绍如何在场景中配置 `GravitySwitch` 与 `GravitySwitchGroup` 组件来制作需要多个角色协作的重力机关/解谜玩法。
+
+## 前置条件
+- 已导入本仓库中的脚本。
+- 场景中存在可供玩家或怪物站立的地面模型。
+
+## 配置单个重力开关 `GravitySwitch`
+1. **添加触发器碰撞体**：
+   - 选择你的地面或机关模型，在 `Inspector` 中点击 `Add Component`。
+   - 添加一个合适的 `Collider`（例如 `Box Collider`）。
+   - `GravitySwitch` 会自动把碰撞体设置为 `Is Trigger = true`，无需手动勾选。
+2. **挂载脚本**：
+   - 在同一对象上点击 `Add Component` 并搜索 `Gravity Switch`，添加脚本。
+3. **设置事件**：
+   - `State Changed Event`：当按压状态发生变化时触发，携带 `bool` 参数表示当前是否被按下。
+   - `On Pressed Event`：任意有效碰撞体第一次踩上开关时触发，只要有玩家/怪物持续站在上面就会保持按下状态。
+   - `On Released Event`：所有有效碰撞体离开或失效（例如对象被禁用/销毁）后触发，开关会立即回弹为未按下。
+   - 可在 Inspector 中直接拖拽其他对象的方法到这些事件槽位，或在代码中通过 `StateChangedEvent` / `OnPressedEvent` / `OnReleasedEvent` 访问。
+4. **检测对象**：
+   - 开关默认只对挂有 `PlayerStateController` 或 `MonsterController`（或其子对象）的碰撞体生效。
+   - 如需扩展，可继承 `GravitySwitch` 并重写 `IsValidActivator` 方法。
+
+## 多个开关串联：`GravitySwitchGroup`
+1. 创建一个空物体，添加 `Gravity Switch Group` 组件。
+2. 在 `Switches` 数组中将需要串联的 `GravitySwitch` 拖入。
+3. 设置 `Required Active Switches`：
+   - 设为 `0`（默认）时表示所有开关都必须被按下。
+   - 设为 `N (>0)` 时表示只要有 `N` 个开关被按下就会激活。
+4. 配置事件：
+   - `State Changed Event`：携带布尔值指示当前组是否激活。
+   - `On Activated Event` / `On Deactivated Event`：在组激活或关闭时触发。
+
+## 示例：控制重力方向
+```csharp
+using UnityEngine;
+using LSP.Gameplay.Interactions;
+
+public class GravityFlipper : MonoBehaviour
+{
+    [SerializeField] private GravitySwitchGroup gravitySwitchGroup;
+    [SerializeField] private Vector3 activeGravity = new Vector3(0, 9.81f, 0f);
+    [SerializeField] private Vector3 inactiveGravity = new Vector3(0, -9.81f, 0f);
+
+    private void OnEnable()
+    {
+        if (gravitySwitchGroup != null)
+        {
+            gravitySwitchGroup.StateChangedEvent.AddListener(OnGroupStateChanged);
+        }
+    }
+
+    private void OnDisable()
+    {
+        if (gravitySwitchGroup != null)
+        {
+            gravitySwitchGroup.StateChangedEvent.RemoveListener(OnGroupStateChanged);
+        }
+    }
+
+    private void OnGroupStateChanged(bool isActive)
+    {
+        Physics.gravity = isActive ? activeGravity : inactiveGravity;
+    }
+}
+```
+> 将该脚本挂在场景任意物体上，把 `Gravity Switch Group` 引用拖入 Inspector。激活后即改变世界重力方向，可根据需要自定义逻辑。
+
+## 调试提示
+- 如果开关无法触发，确认角色的碰撞体是否在触发器层级中，并且对象上存在 `PlayerStateController` 或 `MonsterController` 组件。
+- 使用 `Gizmos` 视图检查触发器的大小是否覆盖玩家/怪物脚底。
+- 若多个开关串联仍无法激活，确认 `Required Active Switches` 设置正确，同时检查是否有重复引用造成忽略。
+


### PR DESCRIPTION
## Summary
- ensure gravity switches continuously validate colliders so switches release as soon as activators leave or are disabled
- document the pressure-plate behavior in the gravity switch usage guide

## Testing
- not run (Unity project code only)

------
https://chatgpt.com/codex/tasks/task_e_68fe321b7f1c8331bb4155097520753e