### PR TITLE
Limit monster detection howls to one at a time

### DIFF
--- a/Assets/Scripts/Audio/MonsterHowlCoordinator.cs
+++ b/Assets/Scripts/Audio/MonsterHowlCoordinator.cs
@@ -1,0 +1,150 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace LSP.Gameplay
+{
+    /// <summary>
+    /// Coordinates monster detection howls so only one plays at a time.
+    /// Attach to a scene object to automatically discover <see cref="MonsterController"/> instances
+    /// and regulate their howling audio.
+    /// </summary>
+    public class MonsterHowlCoordinator : MonoBehaviour
+    {
+        public static MonsterHowlCoordinator Instance { get; private set; }
+
+        private readonly HashSet<MonsterController> registeredMonsters = new HashSet<MonsterController>();
+        private MonsterController activeMonster;
+        private Coroutine releaseRoutine;
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Debug.LogWarning($"Multiple {nameof(MonsterHowlCoordinator)} instances detected. The extra instance will be disabled.", this);
+                enabled = false;
+                return;
+            }
+
+            Instance = this;
+        }
+
+        private void Start()
+        {
+            // Automatically discover monsters already present in the scene.
+            foreach (MonsterController monster in FindObjectsOfType<MonsterController>(true))
+            {
+                RegisterMonster(monster);
+            }
+        }
+
+        private void OnDisable()
+        {
+            ReleaseActiveMonster();
+        }
+
+        private void OnDestroy()
+        {
+            if (Instance == this)
+            {
+                Instance = null;
+            }
+        }
+
+        /// <summary>
+        /// Registers a monster so that the coordinator can keep track of it.
+        /// </summary>
+        public void RegisterMonster(MonsterController monster)
+        {
+            if (monster == null)
+            {
+                return;
+            }
+
+            registeredMonsters.Add(monster);
+        }
+
+        /// <summary>
+        /// Removes a monster from the coordinator, releasing howl control if needed.
+        /// </summary>
+        public void UnregisterMonster(MonsterController monster)
+        {
+            if (monster == null)
+            {
+                return;
+            }
+
+            registeredMonsters.Remove(monster);
+
+            if (activeMonster == monster)
+            {
+                ReleaseActiveMonster();
+            }
+        }
+
+        /// <summary>
+        /// Attempts to start a howl for the specified monster.
+        /// </summary>
+        /// <param name="monster">The requesting monster.</param>
+        /// <param name="durationSeconds">The expected duration of the howl in seconds.</param>
+        /// <returns>True if the howl is allowed to play, otherwise false.</returns>
+        public bool TryBeginHowl(MonsterController monster, float durationSeconds)
+        {
+            if (monster == null)
+            {
+                return false;
+            }
+
+            if (activeMonster != null && activeMonster != monster)
+            {
+                return false;
+            }
+
+            activeMonster = monster;
+
+            if (durationSeconds <= 0f)
+            {
+                ReleaseActiveMonster();
+                return true;
+            }
+
+            if (releaseRoutine != null)
+            {
+                StopCoroutine(releaseRoutine);
+            }
+
+            releaseRoutine = StartCoroutine(ReleaseAfterDelay(durationSeconds));
+            return true;
+        }
+
+        /// <summary>
+        /// Ends the howl for the provided monster, freeing control for others.
+        /// </summary>
+        public void EndHowl(MonsterController monster)
+        {
+            if (monster == null || activeMonster != monster)
+            {
+                return;
+            }
+
+            ReleaseActiveMonster();
+        }
+
+        private IEnumerator ReleaseAfterDelay(float duration)
+        {
+            yield return new WaitForSeconds(duration);
+            ReleaseActiveMonster();
+        }
+
+        private void ReleaseActiveMonster()
+        {
+            if (releaseRoutine != null)
+            {
+                StopCoroutine(releaseRoutine);
+                releaseRoutine = null;
+            }
+
+            activeMonster = null;
+        }
+    }
+}

--- a/Assets/Scripts/MonsterController.cs
+++ b/Assets/Scripts/MonsterController.cs
@@ -144,6 +144,7 @@ namespace LSP.Gameplay
         private PlayerStateController cachedPlayerState;
         private bool returningIgnoresVision;
         private Vector3 previousPosition;
+        private Coroutine detectionHowlReleaseRoutine;
 
         public MonsterState CurrentState => currentState;
         public float CurrentMoveSpeed => IsNavMeshAgentAvailable ? navMeshAgent.speed : fallbackMoveSpeed;
@@ -209,6 +210,7 @@ namespace LSP.Gameplay
             cachedPlayerState = ResolveChaseTargetPlayer();
             returningIgnoresVision = false;
             ApplyAnimatorMovementState();
+            MonsterHowlCoordinator.Instance?.RegisterMonster(this);
         }
 
         private void OnDisable()
@@ -231,6 +233,8 @@ namespace LSP.Gameplay
             returningIgnoresVision = false;
             StopFootstepAudio();
             cachedPlayerState = null;
+            StopDetectionHowlControl();
+            MonsterHowlCoordinator.Instance?.UnregisterMonster(this);
         }
 
         private void Update()
@@ -335,6 +339,21 @@ namespace LSP.Gameplay
 
         private void PlayDetectionHowl()
         {
+            AudioClip howlClip = detectionHowlClip;
+
+            if (howlClip == null && detectionAudioSource != null)
+            {
+                howlClip = detectionAudioSource.clip;
+            }
+
+            float howlDuration = howlClip != null ? howlClip.length : 0f;
+            MonsterHowlCoordinator coordinator = MonsterHowlCoordinator.Instance;
+
+            if (coordinator != null && !coordinator.TryBeginHowl(this, howlDuration))
+            {
+                return;
+            }
+
             if (detectionAudioSource != null)
             {
                 if (detectionHowlClip != null)
@@ -345,14 +364,46 @@ namespace LSP.Gameplay
                 {
                     detectionAudioSource.Play();
                 }
-
-                return;
             }
-
-            if (detectionHowlClip != null)
+            else if (detectionHowlClip != null)
             {
                 AudioSource.PlayClipAtPoint(detectionHowlClip, transform.position);
             }
+
+            if (coordinator != null)
+            {
+                if (howlDuration > 0f)
+                {
+                    if (detectionHowlReleaseRoutine != null)
+                    {
+                        StopCoroutine(detectionHowlReleaseRoutine);
+                    }
+
+                    detectionHowlReleaseRoutine = StartCoroutine(ReleaseHowlAfterDelay(howlDuration));
+                }
+                else
+                {
+                    coordinator.EndHowl(this);
+                }
+            }
+        }
+
+        private IEnumerator ReleaseHowlAfterDelay(float duration)
+        {
+            yield return new WaitForSeconds(duration);
+            MonsterHowlCoordinator.Instance?.EndHowl(this);
+            detectionHowlReleaseRoutine = null;
+        }
+
+        private void StopDetectionHowlControl()
+        {
+            if (detectionHowlReleaseRoutine != null)
+            {
+                StopCoroutine(detectionHowlReleaseRoutine);
+                detectionHowlReleaseRoutine = null;
+            }
+
+            MonsterHowlCoordinator.Instance?.EndHowl(this);
         }
 
         private void UpdateMovement(float deltaTime)


### PR DESCRIPTION
## Summary
- add a MonsterHowlCoordinator that finds monsters in the scene and gates howl playback
- update MonsterController to register with the coordinator and respect its one-at-a-time howl policy

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_6902265011dc8331af12cae4504a4312