### PR TITLE
Add master volume control for monster howls

### DIFF
--- a/Assets/Scripts/Audio/MonsterHowlCoordinator.cs
+++ b/Assets/Scripts/Audio/MonsterHowlCoordinator.cs
@@ -1,0 +1,187 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace LSP.Gameplay
+{
+    /// <summary>
+    /// Coordinates monster detection howls so only one plays at a time.
+    /// Attach to a scene object to automatically discover <see cref="MonsterController"/> instances
+    /// and regulate their howling audio.
+    /// </summary>
+    public class MonsterHowlCoordinator : MonoBehaviour
+    {
+        public static MonsterHowlCoordinator Instance { get; private set; }
+
+        [Header("Audio")]
+        [Range(0f, 1f)]
+        [SerializeField]
+        private float detectionHowlVolume = 1f;
+
+        private readonly HashSet<MonsterController> registeredMonsters = new HashSet<MonsterController>();
+        private MonsterController activeMonster;
+        private Coroutine releaseRoutine;
+
+        public float DetectionHowlVolume => Mathf.Clamp01(detectionHowlVolume);
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Debug.LogWarning($"Multiple {nameof(MonsterHowlCoordinator)} instances detected. The extra instance will be disabled.", this);
+                enabled = false;
+                return;
+            }
+
+            Instance = this;
+        }
+
+        private void Start()
+        {
+            // Automatically discover monsters already present in the scene.
+            foreach (MonsterController monster in FindObjectsOfType<MonsterController>(true))
+            {
+                RegisterMonster(monster);
+            }
+
+            ApplyVolumeToRegisteredMonsters();
+        }
+
+        private void OnValidate()
+        {
+            detectionHowlVolume = Mathf.Clamp01(detectionHowlVolume);
+            ApplyVolumeToRegisteredMonsters();
+        }
+
+        private void OnDisable()
+        {
+            ReleaseActiveMonster();
+        }
+
+        private void OnDestroy()
+        {
+            if (Instance == this)
+            {
+                Instance = null;
+            }
+        }
+
+        /// <summary>
+        /// Registers a monster so that the coordinator can keep track of it.
+        /// </summary>
+        public void RegisterMonster(MonsterController monster)
+        {
+            if (monster == null)
+            {
+                return;
+            }
+
+            registeredMonsters.Add(monster);
+            monster.ApplyDetectionHowlVolume(DetectionHowlVolume);
+        }
+
+        /// <summary>
+        /// Sets the master volume applied to all monster detection howls.
+        /// </summary>
+        public void SetDetectionHowlVolume(float volume)
+        {
+            detectionHowlVolume = Mathf.Clamp01(volume);
+            ApplyVolumeToRegisteredMonsters();
+        }
+
+        /// <summary>
+        /// Removes a monster from the coordinator, releasing howl control if needed.
+        /// </summary>
+        public void UnregisterMonster(MonsterController monster)
+        {
+            if (monster == null)
+            {
+                return;
+            }
+
+            registeredMonsters.Remove(monster);
+
+            if (activeMonster == monster)
+            {
+                ReleaseActiveMonster();
+            }
+        }
+
+        /// <summary>
+        /// Attempts to start a howl for the specified monster.
+        /// </summary>
+        /// <param name="monster">The requesting monster.</param>
+        /// <param name="durationSeconds">The expected duration of the howl in seconds.</param>
+        /// <returns>True if the howl is allowed to play, otherwise false.</returns>
+        public bool TryBeginHowl(MonsterController monster, float durationSeconds)
+        {
+            if (monster == null)
+            {
+                return false;
+            }
+
+            if (activeMonster != null && activeMonster != monster)
+            {
+                return false;
+            }
+
+            activeMonster = monster;
+
+            if (durationSeconds <= 0f)
+            {
+                ReleaseActiveMonster();
+                return true;
+            }
+
+            if (releaseRoutine != null)
+            {
+                StopCoroutine(releaseRoutine);
+            }
+
+            releaseRoutine = StartCoroutine(ReleaseAfterDelay(durationSeconds));
+            return true;
+        }
+
+        /// <summary>
+        /// Ends the howl for the provided monster, freeing control for others.
+        /// </summary>
+        public void EndHowl(MonsterController monster)
+        {
+            if (monster == null || activeMonster != monster)
+            {
+                return;
+            }
+
+            ReleaseActiveMonster();
+        }
+
+        private void ApplyVolumeToRegisteredMonsters()
+        {
+            float volume = DetectionHowlVolume;
+
+            foreach (MonsterController monster in registeredMonsters)
+            {
+                monster?.ApplyDetectionHowlVolume(volume);
+            }
+
+            registeredMonsters.RemoveWhere(monster => monster == null);
+        }
+
+        private IEnumerator ReleaseAfterDelay(float duration)
+        {
+            yield return new WaitForSeconds(duration);
+            ReleaseActiveMonster();
+        }
+
+        private void ReleaseActiveMonster()
+        {
+            if (releaseRoutine != null)
+            {
+                StopCoroutine(releaseRoutine);
+                releaseRoutine = null;
+            }
+
+            activeMonster = null;
+        }
+    }
+}

--- a/Assets/Scripts/MonsterController.cs
+++ b/Assets/Scripts/MonsterController.cs
@@ -144,6 +144,9 @@ namespace LSP.Gameplay
         private PlayerStateController cachedPlayerState;
         private bool returningIgnoresVision;
         private Vector3 previousPosition;
+        private Coroutine detectionHowlReleaseRoutine;
+        private float detectionHowlBaseVolume = 1f;
+        private float detectionHowlVolumeMultiplier = 1f;
 
         public MonsterState CurrentState => currentState;
         public float CurrentMoveSpeed => IsNavMeshAgentAvailable ? navMeshAgent.speed : fallbackMoveSpeed;
@@ -193,10 +196,17 @@ namespace LSP.Gameplay
 
             if (detectionAudioSource != null)
             {
+                detectionHowlBaseVolume = detectionAudioSource.volume;
                 detectionAudioSource.loop = false;
                 detectionAudioSource.playOnAwake = false;
                 detectionAudioSource.Stop();
             }
+            else
+            {
+                detectionHowlBaseVolume = 1f;
+            }
+
+            detectionHowlVolumeMultiplier = 1f;
         }
 
         private void OnEnable()
@@ -209,6 +219,7 @@ namespace LSP.Gameplay
             cachedPlayerState = ResolveChaseTargetPlayer();
             returningIgnoresVision = false;
             ApplyAnimatorMovementState();
+            MonsterHowlCoordinator.Instance?.RegisterMonster(this);
         }
 
         private void OnDisable()
@@ -231,6 +242,8 @@ namespace LSP.Gameplay
             returningIgnoresVision = false;
             StopFootstepAudio();
             cachedPlayerState = null;
+            StopDetectionHowlControl();
+            MonsterHowlCoordinator.Instance?.UnregisterMonster(this);
         }
 
         private void Update()
@@ -333,8 +346,36 @@ namespace LSP.Gameplay
             }
         }
 
+        public void ApplyDetectionHowlVolume(float volumeMultiplier)
+        {
+            detectionHowlVolumeMultiplier = Mathf.Clamp01(volumeMultiplier);
+
+            if (detectionAudioSource != null)
+            {
+                detectionAudioSource.volume = detectionHowlBaseVolume * detectionHowlVolumeMultiplier;
+            }
+        }
+
         private void PlayDetectionHowl()
         {
+            AudioClip howlClip = detectionHowlClip;
+
+            if (howlClip == null && detectionAudioSource != null)
+            {
+                howlClip = detectionAudioSource.clip;
+            }
+
+            float howlDuration = howlClip != null ? howlClip.length : 0f;
+            MonsterHowlCoordinator coordinator = MonsterHowlCoordinator.Instance;
+            float howlVolumeMultiplier = coordinator != null ? coordinator.DetectionHowlVolume : 1f;
+
+            if (coordinator != null && !coordinator.TryBeginHowl(this, howlDuration))
+            {
+                return;
+            }
+
+            ApplyDetectionHowlVolume(howlVolumeMultiplier);
+
             if (detectionAudioSource != null)
             {
                 if (detectionHowlClip != null)
@@ -345,14 +386,47 @@ namespace LSP.Gameplay
                 {
                     detectionAudioSource.Play();
                 }
-
-                return;
             }
-
-            if (detectionHowlClip != null)
+            else if (detectionHowlClip != null)
             {
-                AudioSource.PlayClipAtPoint(detectionHowlClip, transform.position);
+                float playbackVolume = detectionHowlBaseVolume * detectionHowlVolumeMultiplier;
+                AudioSource.PlayClipAtPoint(detectionHowlClip, transform.position, playbackVolume);
             }
+
+            if (coordinator != null)
+            {
+                if (howlDuration > 0f)
+                {
+                    if (detectionHowlReleaseRoutine != null)
+                    {
+                        StopCoroutine(detectionHowlReleaseRoutine);
+                    }
+
+                    detectionHowlReleaseRoutine = StartCoroutine(ReleaseHowlAfterDelay(howlDuration));
+                }
+                else
+                {
+                    coordinator.EndHowl(this);
+                }
+            }
+        }
+
+        private IEnumerator ReleaseHowlAfterDelay(float duration)
+        {
+            yield return new WaitForSeconds(duration);
+            MonsterHowlCoordinator.Instance?.EndHowl(this);
+            detectionHowlReleaseRoutine = null;
+        }
+
+        private void StopDetectionHowlControl()
+        {
+            if (detectionHowlReleaseRoutine != null)
+            {
+                StopCoroutine(detectionHowlReleaseRoutine);
+                detectionHowlReleaseRoutine = null;
+            }
+
+            MonsterHowlCoordinator.Instance?.EndHowl(this);
         }
 
         private void UpdateMovement(float deltaTime)


### PR DESCRIPTION
## Summary
- add a configurable detection howl volume to `MonsterHowlCoordinator` and propagate updates to all registered monsters
- apply the coordinator volume when monsters play their detection howl audio sources or fallback clip playback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6902265011dc8331af12cae4504a4312