### PR TITLE
Apply new heart-rate movement curve and vision slowdown

### DIFF
--- a/Assets/Scripts/EyeWetnessUI.cs
+++ b/Assets/Scripts/EyeWetnessUI.cs
@@ -34,33 +34,12 @@ namespace LSP.Gameplay
 
         private void OnEnable()
         {
-            UpdateSliderImmediate();
-        }
-
-        private void Update()
-        {
-            UpdateSliderImmediate();
-        }
-
-        private void UpdateSliderImmediate()
-        {
-            if (wetnessSlider == null || eyeControl == null)
+            if (wetnessSlider != null)
             {
-                return;
+                wetnessSlider.gameObject.SetActive(false);
             }
 
-            float maxWetness = Mathf.Max(eyeControl.MaximumWetness, Mathf.Epsilon);
-            float wetnessValue = Mathf.Clamp(eyeControl.CurrentWetness, 0f, maxWetness);
-
-            if (useNormalisedValue)
-            {
-                wetnessSlider.normalizedValue = wetnessValue / maxWetness;
-            }
-            else
-            {
-                wetnessSlider.maxValue = maxWetness;
-                wetnessSlider.value = wetnessValue;
-            }
+            enabled = false;
         }
     }
 }

--- a/Assets/Scripts/GameplayDebugPanel.cs
+++ b/Assets/Scripts/GameplayDebugPanel.cs
@@ -22,6 +22,7 @@ namespace LSP.Gameplay
         [SerializeField] private PlayerEyeControl eyeControl;
         [SerializeField] private PlayerVision playerVision;
         [SerializeField] private Camera playerCamera;
+        [SerializeField] private HeartRateMovementController heartRateMovement;
 
         [Header("Tracked Collections")]
         [SerializeField] private List<MonsterController> trackedMonsters = new List<MonsterController>();
@@ -46,22 +47,6 @@ namespace LSP.Gameplay
         [SerializeField] private float perspectiveFovMax = 100f;
         [SerializeField] private float orthographicSizeMin = 1f;
         [SerializeField] private float orthographicSizeMax = 20f;
-
-        [Header("Eye Wetness Ranges")]
-        [SerializeField] private float eyeMaximumWetnessMin = 1f;
-        [SerializeField] private float eyeMaximumWetnessMax = 10f;
-
-        [SerializeField] private float eyeDryingRateMin = 0f;
-        [SerializeField] private float eyeDryingRateMax = 5f;
-
-        [SerializeField] private float eyeRecoveryRateMin = 0f;
-        [SerializeField] private float eyeRecoveryRateMax = 5f;
-
-        [SerializeField] private float eyeForcedOpenThresholdMin = 0f;
-        [SerializeField] private float eyeForcedOpenThresholdMax = 10f;
-
-        [SerializeField] private float eyeForcedCloseDurationMin = 0f;
-        [SerializeField] private float eyeForcedCloseDurationMax = 10f;
 
         [Header("Persistence")]
         [Tooltip("File name used when persisting debug-tuned values. Stored under Application.persistentDataPath.")]
@@ -113,6 +98,9 @@ namespace LSP.Gameplay
 
             if (playerCamera == null)
                 playerCamera = TryResolveCamera();
+
+            if (heartRateMovement == null)
+                heartRateMovement = FindObjectOfType<HeartRateMovementController>();
 
             settingsFilePath = GameplayDebugSettingsStore.ResolvePath(settingsFileName);
             persistedSettings = GameplayDebugSettingsStore.Load(settingsFileName);
@@ -209,72 +197,71 @@ namespace LSP.Gameplay
                 persistedSettings.PlayerSpeed = newSpeed;
             }
 
-            // Eye controls
-            GameplayDebugSettingsData settings = persistedSettings ??= new GameplayDebugSettingsData();
-
-            if (eyeControl != null)
-            {
-                GUILayout.Label($"Eyes Open: {eyeControl.EyesOpen}");
-                GUILayout.Label($"Forced Closed: {eyeControl.IsForcedClosing}");
-                GUILayout.Label($"Wetness: {eyeControl.CurrentWetness:F2} / {eyeControl.MaximumWetness:F2}");
-            }
-            else
-            {
-                GUILayout.Label("PlayerEyeControl not assigned.");
-            }
-
-            float currentMaxWetness = eyeControl != null ? eyeControl.MaximumWetness : settings.EyeMaximumWetness;
-            float newMaxWetness = DrawSlider("Max Wetness", currentMaxWetness, eyeMaximumWetnessMin, eyeMaximumWetnessMax);
-            if (!Mathf.Approximately(newMaxWetness, currentMaxWetness))
-            {
-                if (eyeControl != null) eyeControl.MaximumWetness = newMaxWetness;
-                settings.EyeMaximumWetness = newMaxWetness;
-
-                if (settings.EyeForcedOpenThreshold > newMaxWetness)
-                    settings.EyeForcedOpenThreshold = Mathf.Min(newMaxWetness, eyeForcedOpenThresholdMax);
-            }
-
-            float currentDryingRate = eyeControl != null ? eyeControl.DryingRate : settings.EyeDryingRate;
-            float newDryingRate = DrawSlider("Drying Rate", currentDryingRate, eyeDryingRateMin, eyeDryingRateMax);
-            if (!Mathf.Approximately(newDryingRate, currentDryingRate))
-            {
-                if (eyeControl != null) eyeControl.DryingRate = newDryingRate;
-                settings.EyeDryingRate = newDryingRate;
-            }
-
-            float currentRecoveryRate = eyeControl != null ? eyeControl.RecoveryRate : settings.EyeRecoveryRate;
-            float newRecoveryRate = DrawSlider("Recovery Rate", currentRecoveryRate, eyeRecoveryRateMin, eyeRecoveryRateMax);
-            if (!Mathf.Approximately(newRecoveryRate, currentRecoveryRate))
-            {
-                if (eyeControl != null) eyeControl.RecoveryRate = newRecoveryRate;
-                settings.EyeRecoveryRate = newRecoveryRate;
-            }
-
-            float forcedOpenMax = Mathf.Min(
-                eyeForcedOpenThresholdMax,
-                Mathf.Max(eyeForcedOpenThresholdMin, eyeControl != null ? eyeControl.MaximumWetness : settings.EyeMaximumWetness)
-            );
-            /*float currentForcedOpenThreshold = eyeControl != null ? eyeControl.ForcedOpenThreshold : settings.EyeForcedOpenThreshold;
-            currentForcedOpenThreshold = Mathf.Clamp(currentForcedOpenThreshold, eyeForcedOpenThresholdMin, forcedOpenMax);
-            float newForcedOpenThreshold = DrawSlider("Forced Open Threshold", currentForcedOpenThreshold, eyeForcedOpenThresholdMin, forcedOpenMax);
-            if (!Mathf.Approximately(newForcedOpenThreshold, currentForcedOpenThreshold))
-            {
-                if (eyeControl != null) eyeControl.ForcedOpenThreshold = newForcedOpenThreshold;
-                settings.EyeForcedOpenThreshold = newForcedOpenThreshold;
-            }
-
-            float currentForcedCloseDuration = eyeControl != null ? eyeControl.ForcedCloseDuration : settings.EyeForcedCloseDuration;
-            float newForcedCloseDuration = DrawSlider("Forced Close Duration", currentForcedCloseDuration, eyeForcedCloseDurationMin, eyeForcedCloseDurationMax);
-            if (!Mathf.Approximately(newForcedCloseDuration, currentForcedCloseDuration))
-            {
-                if (eyeControl != null) eyeControl.ForcedCloseDuration = newForcedCloseDuration;
-                settings.EyeForcedCloseDuration = newForcedCloseDuration;
-            }*/
+            DrawHeartRateControls();
 
             if (playerVision != null)
             {
                 GUILayout.Label($"Vision Range: {playerVision.MaxDetectionDistance:F1}");
             }
+        }
+
+        private void DrawHeartRateControls()
+        {
+            GUILayout.Space(6f);
+            GUILayout.Label("Heart Rate Movement", headerStyle);
+
+            if (heartRateMovement == null)
+            {
+                GUILayout.Label("HeartRateMovementController not assigned.");
+                return;
+            }
+
+            int currentHr = HyperateGlobal.Instance != null ? HyperateGlobal.Instance.CurrentHeartRate : 0;
+            GUILayout.Label($"Current HR: {(currentHr > 0 ? currentHr.ToString() : "N/A")} bpm");
+            GUILayout.Label($"Resting HR: {heartRateMovement.RestingHeartRate:F1} bpm → Target: {heartRateMovement.TargetHeartRate:F1} bpm");
+            GUILayout.Label($"Calibration: {(heartRateMovement.IsCalibrating ? "In Progress" : (heartRateMovement.ManualRestingHeartRate > 0f ? "Manual" : "Complete"))}");
+
+            float newManualRest = DrawSlider("Manual Resting HR", heartRateMovement.ManualRestingHeartRate, 40f, 120f);
+            if (!Mathf.Approximately(newManualRest, heartRateMovement.ManualRestingHeartRate))
+            {
+                heartRateMovement.ManualRestingHeartRate = newManualRest;
+                if (newManualRest > 0f)
+                {
+                    heartRateMovement.SetRestingHeartRate(newManualRest);
+                }
+            }
+
+            float newOffset = DrawSlider("δ offset (bpm)", heartRateMovement.ActivationOffsetBpm, 0f, 30f);
+            if (!Mathf.Approximately(newOffset, heartRateMovement.ActivationOffsetBpm))
+                heartRateMovement.ActivationOffsetBpm = newOffset;
+
+            float newNormal = DrawSlider("Vnorm", heartRateMovement.NormalSpeed, playerSpeedMin, playerSpeedMax);
+            if (!Mathf.Approximately(newNormal, heartRateMovement.NormalSpeed))
+                heartRateMovement.NormalSpeed = newNormal;
+
+            float newMin = DrawSlider("Vmin", heartRateMovement.MinimumSpeed, playerSpeedMin, playerSpeedMax);
+            if (!Mathf.Approximately(newMin, heartRateMovement.MinimumSpeed))
+                heartRateMovement.MinimumSpeed = newMin;
+
+            float newMax = DrawSlider("Vmax", heartRateMovement.MaximumSpeed, playerSpeedMin, playerSpeedMax);
+            if (!Mathf.Approximately(newMax, heartRateMovement.MaximumSpeed))
+                heartRateMovement.MaximumSpeed = newMax;
+
+            float newDecel = DrawSlider("Rdec (bpm)", heartRateMovement.DecelerationRangeBpm, 1f, 40f);
+            if (!Mathf.Approximately(newDecel, heartRateMovement.DecelerationRangeBpm))
+                heartRateMovement.DecelerationRangeBpm = newDecel;
+
+            float newAccel = DrawSlider("Racc (bpm)", heartRateMovement.AccelerationRangeBpm, 1f, 60f);
+            if (!Mathf.Approximately(newAccel, heartRateMovement.AccelerationRangeBpm))
+                heartRateMovement.AccelerationRangeBpm = newAccel;
+
+            float newGrace = DrawSlider("Below Target Grace (s)", heartRateMovement.BelowTargetGraceSeconds, 0f, 15f);
+            if (!Mathf.Approximately(newGrace, heartRateMovement.BelowTargetGraceSeconds))
+                heartRateMovement.BelowTargetGraceSeconds = newGrace;
+
+            float newBand = DrawSlider("Below Target Warning Band (bpm)", heartRateMovement.BelowTargetWarningBandBpm, 0f, 30f);
+            if (!Mathf.Approximately(newBand, heartRateMovement.BelowTargetWarningBandBpm))
+                heartRateMovement.BelowTargetWarningBandBpm = newBand;
         }
 
         private void DrawMonsterControls()
@@ -417,6 +404,7 @@ namespace LSP.Gameplay
             if (eyeControl == null) eyeControl = FindObjectOfType<PlayerEyeControl>();
             if (playerVision == null) playerVision = FindObjectOfType<PlayerVision>();
             if (playerCamera == null) playerCamera = TryResolveCamera();
+            if (heartRateMovement == null) heartRateMovement = FindObjectOfType<HeartRateMovementController>();
 
             AddUniqueRange(trackedMonsters, FindObjectsOfType<MonsterController>());
             AddUniqueRange(trackedNpcs, FindObjectsOfType<NpcDeadStareController>());

--- a/Assets/Scripts/HypeRate/HeartRateMovementController.cs
+++ b/Assets/Scripts/HypeRate/HeartRateMovementController.cs
@@ -1,0 +1,321 @@
+using System.Collections.Generic;
+using UnityEngine;
+using StarterAssets;
+
+namespace LSP.Gameplay
+{
+    /// <summary>
+    /// Drives the player's movement speed directly from heart rate data using the
+    /// provided physiological baseline and tuning curve.
+    /// </summary>
+    public class HeartRateMovementController : MonoBehaviour
+    {
+        [Header("References")]
+        [SerializeField] private FirstPersonController firstPersonController;
+
+        [Header("Calibration")]
+        [Tooltip("Automatically begins the resting heart rate calibration when the object awakens.")]
+        [SerializeField] private bool autoStartCalibration = true;
+
+        [Tooltip("Duration of the calibration window in seconds (samples are taken once per second).")]
+        [SerializeField] private float calibrationDurationSeconds = 180f;
+
+        [Tooltip("Initial portion of the calibration window to discard to avoid ramp-up noise.")]
+        [SerializeField] private float calibrationDiscardInitialSeconds = 10f;
+
+        [Tooltip("Minimum number of samples required to accept the calibration result.")]
+        [SerializeField] private int calibrationMinimumSamples = 30;
+
+        [Header("Heart Rate Targets")]
+        [Tooltip("Heart rate must exceed the resting value by this offset to hit the neutral speed.")]
+        [SerializeField] private float activationOffsetBpm = 8f;
+
+        [Tooltip("Speed applied when the player's heart rate exactly meets the target.")]
+        [SerializeField] private float normalSpeed = 3.5f;
+
+        [Tooltip("Minimum speed applied when the heart rate is well below the target.")]
+        [SerializeField] private float minimumSpeed = 0.5f;
+
+        [Tooltip("Maximum speed applied when the heart rate is well above the target.")]
+        [SerializeField] private float maximumSpeed = 6f;
+
+        [Tooltip("Heart rate band below the target before speed reaches the minimum.")]
+        [SerializeField] private float decelerationRangeBpm = 15f;
+
+        [Tooltip("Heart rate band above the target before speed reaches the maximum.")]
+        [SerializeField] private float accelerationRangeBpm = 25f;
+
+        [Header("Low Heart Rate Feedback")]
+        [Tooltip("Seconds the player can stay below the target without feedback.")]
+        [SerializeField] private float belowTargetGraceSeconds = 5f;
+
+        [Tooltip("Maximum shortfall (bpm) from the target that still triggers the warning overlay after the grace period.")]
+        [SerializeField] private float belowTargetWarningBandBpm = 10f;
+
+        [Tooltip("Optional UI object toggled when the player stays below the target.")]
+        [SerializeField] private GameObject lowHeartRateWarningUI;
+
+        [Tooltip("Optional overlay object that tints the screen red when below target beyond the grace period.")]
+        [SerializeField] private GameObject redTintOverlay;
+
+        [Header("Debug")]
+        [Tooltip("Resting heart rate determined from calibration. Can be set manually for testing.")]
+        [SerializeField] private float restingHeartRate = 70f;
+
+        [Tooltip("Overrides the resting heart rate when set > 0, skipping calibration.")]
+        [SerializeField] private float manualRestingHeartRate;
+
+        private readonly List<HeartSample> calibrationSamples = new List<HeartSample>();
+        private float calibrationTimer;
+        private bool isCalibrating;
+
+        private float sprintToMoveRatio = 1f;
+        private float belowTargetTimer;
+
+        private struct HeartSample
+        {
+            public float Time;
+            public int Bpm;
+        }
+
+        public float RestingHeartRate => restingHeartRate;
+        public float TargetHeartRate => restingHeartRate + activationOffsetBpm;
+        public bool IsCalibrating => isCalibrating;
+
+        public float ActivationOffsetBpm
+        {
+            get => activationOffsetBpm;
+            set => activationOffsetBpm = Mathf.Max(0f, value);
+        }
+
+        public float NormalSpeed
+        {
+            get => normalSpeed;
+            set => normalSpeed = Mathf.Max(0f, value);
+        }
+
+        public float MinimumSpeed
+        {
+            get => minimumSpeed;
+            set => minimumSpeed = Mathf.Max(0f, value);
+        }
+
+        public float MaximumSpeed
+        {
+            get => maximumSpeed;
+            set => maximumSpeed = Mathf.Max(0f, value);
+        }
+
+        public float DecelerationRangeBpm
+        {
+            get => decelerationRangeBpm;
+            set => decelerationRangeBpm = Mathf.Max(0f, value);
+        }
+
+        public float AccelerationRangeBpm
+        {
+            get => accelerationRangeBpm;
+            set => accelerationRangeBpm = Mathf.Max(0f, value);
+        }
+
+        public float BelowTargetGraceSeconds
+        {
+            get => belowTargetGraceSeconds;
+            set => belowTargetGraceSeconds = Mathf.Max(0f, value);
+        }
+
+        public float BelowTargetWarningBandBpm
+        {
+            get => belowTargetWarningBandBpm;
+            set => belowTargetWarningBandBpm = Mathf.Max(0f, value);
+        }
+
+        public float ManualRestingHeartRate
+        {
+            get => manualRestingHeartRate;
+            set => manualRestingHeartRate = Mathf.Max(0f, value);
+        }
+
+        public void SetRestingHeartRate(float value)
+        {
+            restingHeartRate = Mathf.Max(0f, value);
+            isCalibrating = false;
+        }
+
+        private void Reset()
+        {
+            firstPersonController = GetComponent<FirstPersonController>();
+        }
+
+        private void Awake()
+        {
+            if (firstPersonController == null)
+            {
+                firstPersonController = GetComponent<FirstPersonController>();
+            }
+
+            if (firstPersonController != null && firstPersonController.MoveSpeed > 0f)
+            {
+                sprintToMoveRatio = firstPersonController.SprintSpeed / firstPersonController.MoveSpeed;
+                normalSpeed = Mathf.Approximately(normalSpeed, 0f) ? firstPersonController.MoveSpeed : normalSpeed;
+            }
+
+            if (autoStartCalibration && manualRestingHeartRate <= 0f)
+            {
+                BeginCalibration();
+            }
+            else if (manualRestingHeartRate > 0f)
+            {
+                restingHeartRate = manualRestingHeartRate;
+            }
+        }
+
+        private void Update()
+        {
+            int currentHeartRate = HyperateGlobal.Instance != null ? HyperateGlobal.Instance.CurrentHeartRate : 0;
+
+            if (isCalibrating)
+            {
+                UpdateCalibration(Time.deltaTime, currentHeartRate);
+            }
+
+            ApplyMovementSpeed(currentHeartRate);
+            UpdateLowHeartRateFeedback(currentHeartRate, Time.deltaTime);
+        }
+
+        public void BeginCalibration()
+        {
+            calibrationSamples.Clear();
+            calibrationTimer = 0f;
+            isCalibrating = true;
+        }
+
+        private void UpdateCalibration(float deltaTime, int currentHeartRate)
+        {
+            calibrationTimer += deltaTime;
+            float elapsedSeconds = calibrationTimer;
+
+            if (elapsedSeconds >= calibrationDurationSeconds)
+            {
+                CompleteCalibration();
+                return;
+            }
+
+            if (currentHeartRate <= 0)
+            {
+                return;
+            }
+
+            if (Mathf.FloorToInt(elapsedSeconds) > calibrationSamples.Count)
+            {
+                calibrationSamples.Add(new HeartSample { Time = elapsedSeconds, Bpm = currentHeartRate });
+            }
+        }
+
+        private void CompleteCalibration()
+        {
+            isCalibrating = false;
+
+            List<int> usableSamples = new List<int>();
+            foreach (HeartSample sample in calibrationSamples)
+            {
+                if (sample.Time >= calibrationDiscardInitialSeconds)
+                {
+                    usableSamples.Add(sample.Bpm);
+                }
+            }
+
+            if (usableSamples.Count < calibrationMinimumSamples)
+            {
+                return;
+            }
+
+            usableSamples.Sort();
+            if (usableSamples.Count > 2)
+            {
+                usableSamples.RemoveAt(0);
+                usableSamples.RemoveAt(usableSamples.Count - 1);
+            }
+
+            float sum = 0f;
+            foreach (int bpm in usableSamples)
+            {
+                sum += bpm;
+            }
+
+            restingHeartRate = sum / usableSamples.Count;
+        }
+
+        private void ApplyMovementSpeed(int currentHeartRate)
+        {
+            if (firstPersonController == null)
+            {
+                return;
+            }
+
+            float targetSpeed = CalculateSpeed(currentHeartRate);
+            firstPersonController.MoveSpeed = targetSpeed;
+            firstPersonController.SprintSpeed = targetSpeed * sprintToMoveRatio;
+        }
+
+        private float CalculateSpeed(int currentHeartRate)
+        {
+            float target = TargetHeartRate;
+            float delta = currentHeartRate - target;
+
+            if (Mathf.Approximately(delta, 0f))
+            {
+                return normalSpeed;
+            }
+
+            if (delta < 0f)
+            {
+                float shortfall = Mathf.Abs(delta);
+                float t = decelerationRangeBpm > 0f ? Mathf.Min(1f, shortfall / decelerationRangeBpm) : 1f;
+                return Mathf.Lerp(normalSpeed, minimumSpeed, t);
+            }
+
+            float climb = accelerationRangeBpm > 0f ? Mathf.Min(1f, delta / accelerationRangeBpm) : 1f;
+            return Mathf.Lerp(normalSpeed, maximumSpeed, climb);
+        }
+
+        private void UpdateLowHeartRateFeedback(int currentHeartRate, float deltaTime)
+        {
+            bool belowTarget = currentHeartRate > 0 && currentHeartRate < TargetHeartRate;
+
+            if (belowTarget)
+            {
+                belowTargetTimer += deltaTime;
+            }
+            else
+            {
+                belowTargetTimer = 0f;
+                SetWarningActive(false);
+                return;
+            }
+
+            if (belowTargetTimer <= belowTargetGraceSeconds)
+            {
+                SetWarningActive(false);
+                return;
+            }
+
+            float shortfall = TargetHeartRate - currentHeartRate;
+            bool withinBand = belowTargetWarningBandBpm <= 0f || shortfall <= belowTargetWarningBandBpm;
+            SetWarningActive(withinBand);
+        }
+
+        private void SetWarningActive(bool active)
+        {
+            if (lowHeartRateWarningUI != null && lowHeartRateWarningUI.activeSelf != active)
+            {
+                lowHeartRateWarningUI.SetActive(active);
+            }
+
+            if (redTintOverlay != null && redTintOverlay.activeSelf != active)
+            {
+                redTintOverlay.SetActive(active);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/MonsterController.cs
+++ b/Assets/Scripts/MonsterController.cs
@@ -51,6 +51,16 @@ namespace LSP.Gameplay
         [SerializeField]
         private float visionHoldDuration = 0.2f;
 
+        [Tooltip("Movement multiplier applied while the monster is inside the player's view.")]
+        [Range(0f, 1f)]
+        [SerializeField]
+        private float visionSlowMultiplier = 0.2f;
+
+        [Tooltip("Animator speed multiplier while the monster is slowed by vision.")]
+        [Range(0f, 1f)]
+        [SerializeField]
+        private float visionAnimatorSpeedMultiplier = 0.4f;
+
         [Header("NavMesh")]
         [SerializeField]
         private NavMeshAgent navMeshAgent;
@@ -138,6 +148,9 @@ namespace LSP.Gameplay
         private bool animatorFrozenByVision;
         private float cachedAnimatorSpeed = 1f;
         private bool cachedAnimatorEnabled = true;
+        private bool slowedByVision;
+        private bool animatorSlowedByVision;
+        private float cachedAnimatorSpeedFromVision = 1f;
         private int walkingStateHash;
         private bool walkingStateAvailable;
         private bool restartTriggered;
@@ -258,6 +271,9 @@ namespace LSP.Gameplay
                     StopNavMeshAgent();
                 }
 
+                ClearVisionSlowdown();
+                RestoreAnimatorFromVision();
+
                 ApplyAnimatorMovementState();
                 CheckForProximityRestart();
                 UpdateFootstepAudio(0f);
@@ -293,21 +309,21 @@ namespace LSP.Gameplay
             timeSinceLastSeen = inView ? 0f : timeSinceLastSeen + deltaTime;
 
             bool allowVisionControl = currentState != MonsterState.Returning || !returningIgnoresVision;
-            bool shouldHoldStationary = allowVisionControl && (inView || timeSinceLastSeen < visionHoldDuration);
+            bool shouldSlowFromVision = allowVisionControl && (inView || timeSinceLastSeen < visionHoldDuration);
 
             if (canChase && currentState == MonsterState.Stationary)
             {
                 currentState = MonsterState.Chasing;
             }
 
-            if (shouldHoldStationary)
+            if (shouldSlowFromVision)
             {
-                FreezeMoveSpeed();
-                FreezeAnimatorByVision();
+                ApplyVisionSlowdown();
+                ApplyAnimatorVisionSlowdown();
             }
             else
             {
-                RestoreMoveSpeed();
+                ClearVisionSlowdown();
                 RestoreAnimatorFromVision();
 
                 if (currentState == MonsterState.Stationary)
@@ -734,6 +750,40 @@ namespace LSP.Gameplay
             }
         }
 
+        private void ApplyVisionSlowdown()
+        {
+            if (isMoveSpeedFrozen)
+            {
+                return;
+            }
+
+            float clampedMultiplier = Mathf.Clamp01(visionSlowMultiplier);
+            ApplyMoveSpeed(desiredMoveSpeed * clampedMultiplier);
+            slowedByVision = true;
+
+            if (IsNavMeshAgentAvailable && !navMeshAgent.enabled)
+            {
+                navMeshAgent.enabled = true;
+            }
+        }
+
+        private void ClearVisionSlowdown()
+        {
+            if (!slowedByVision)
+            {
+                return;
+            }
+
+            slowedByVision = false;
+
+            if (!isMoveSpeedFrozen)
+            {
+                ApplyMoveSpeed(desiredMoveSpeed);
+            }
+
+            RestoreAnimatorSpeedFromVisionSlowdown();
+        }
+
         private void FreezeAnimatorByVision()
         {
             if (animator == null || animatorFrozenByVision)
@@ -759,7 +809,45 @@ namespace LSP.Gameplay
             animator.enabled = cachedAnimatorEnabled;
             animator.speed = cachedAnimatorSpeed;
             animatorFrozenByVision = false;
+            RestoreAnimatorSpeedFromVisionSlowdown();
             ApplyAnimatorMovementState();
+        }
+
+        private void ApplyAnimatorVisionSlowdown()
+        {
+            if (animator == null || animatorFrozenByVision)
+            {
+                return;
+            }
+
+            float clampedMultiplier = Mathf.Clamp01(visionAnimatorSpeedMultiplier);
+
+            if (animatorSlowedByVision && Mathf.Approximately(clampedMultiplier, 1f))
+            {
+                RestoreAnimatorSpeedFromVisionSlowdown();
+                return;
+            }
+
+            if (animatorSlowedByVision)
+            {
+                animator.speed = cachedAnimatorSpeedFromVision * clampedMultiplier;
+                return;
+            }
+
+            cachedAnimatorSpeedFromVision = animator.speed;
+            animator.speed = cachedAnimatorSpeedFromVision * clampedMultiplier;
+            animatorSlowedByVision = true;
+        }
+
+        private void RestoreAnimatorSpeedFromVisionSlowdown()
+        {
+            if (animator == null || animatorFrozenByVision || !animatorSlowedByVision)
+            {
+                return;
+            }
+
+            animator.speed = cachedAnimatorSpeedFromVision;
+            animatorSlowedByVision = false;
         }
 
         private void RestoreMoveSpeed()
@@ -770,6 +858,9 @@ namespace LSP.Gameplay
             }
 
             isMoveSpeedFrozen = false;
+
+            slowedByVision = false;
+            RestoreAnimatorSpeedFromVisionSlowdown();
 
             if (navAgentDisabledByVision)
             {

--- a/Assets/Scripts/PlayerEyeControl.cs
+++ b/Assets/Scripts/PlayerEyeControl.cs
@@ -4,7 +4,8 @@ using UnityEngine;
 namespace LSP.Gameplay
 {
     /// <summary>
-    /// Manages the player's eye wetness resource, supporting manual blinking and forced closing.
+    /// Manages the player's eye wetness resource. The wetness UI and blink behaviour are disabled by
+    /// default per the updated design requirements.
     /// </summary>
     public class PlayerEyeControl : MonoBehaviour
     {
@@ -64,6 +65,11 @@ namespace LSP.Gameplay
         [Tooltip("Delay between warning blink sequences while the wetness remains below the threshold.")]
         [SerializeField]
         private float warningBlinkCooldown = 4f;
+
+        [Header("Runtime Overrides")]
+        [Tooltip("When enabled, the wetness resource no longer depletes and the player never blinks.")]
+        [SerializeField]
+        private bool disableWetnessAndBlinking = true;
 
         private float currentWetness;
         private float forcedBlinkTimer;
@@ -151,6 +157,12 @@ namespace LSP.Gameplay
 
         private void Update()
         {
+            if (disableWetnessAndBlinking)
+            {
+                MaintainOpenEyes();
+                return;
+            }
+
             float deltaTime = Time.deltaTime;
             UpdateBlinkTimers(deltaTime);
             HandleInput();
@@ -160,6 +172,11 @@ namespace LSP.Gameplay
 
         private void HandleInput()
         {
+            if (disableWetnessAndBlinking)
+            {
+                return;
+            }
+
             if (IsForcedClosing || IsManualBlinking)
             {
                 return;
@@ -199,6 +216,12 @@ namespace LSP.Gameplay
 
         private void UpdateWarningBlink(float deltaTime)
         {
+            if (disableWetnessAndBlinking)
+            {
+                CancelWarningBlink(false);
+                return;
+            }
+
             if (warningBlinkCooldownTimer > 0f)
             {
                 warningBlinkCooldownTimer -= deltaTime;
@@ -244,6 +267,12 @@ namespace LSP.Gameplay
 
         private void UpdateWetness(float deltaTime)
         {
+            if (disableWetnessAndBlinking)
+            {
+                currentWetness = maximumWetness;
+                return;
+            }
+
             if (EyesOpen)
             {
                 currentWetness -= dryingRate * deltaTime;
@@ -263,6 +292,11 @@ namespace LSP.Gameplay
 
         private void BeginManualBlink()
         {
+            if (disableWetnessAndBlinking)
+            {
+                return;
+            }
+
             CancelWarningBlink(false);
             warningBlinkCooldownTimer = warningBlinkCooldown;
             manualBlinkTimer = manualBlinkDuration;
@@ -280,6 +314,11 @@ namespace LSP.Gameplay
         private void BeginForcedBlink()
         {
             if (IsForcedClosing)
+            {
+                return;
+            }
+
+            if (disableWetnessAndBlinking)
             {
                 return;
             }
@@ -353,6 +392,16 @@ namespace LSP.Gameplay
             warningBlinkTimer = 0f;
             warningBlinkCooldownTimer = 0f;
             eyesOpen = true;
+        }
+
+        private void MaintainOpenEyes()
+        {
+            eyesOpen = true;
+            currentWetness = maximumWetness;
+            forcedBlinkTimer = 0f;
+            manualBlinkTimer = 0f;
+            warningBlinkTimer = 0f;
+            warningBlinkCooldownTimer = 0f;
         }
 
         private float GetWarningBlinkDuration()


### PR DESCRIPTION
## Summary
- implement resting heart-rate calibration, offset-based speed curve, and below-target warning hooks
- disable eye wetness/blink mechanics and hide the wetness UI
- slow monsters when viewed instead of freezing and update the debug panel for the new heart-rate tuning fields

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923b6bc4e2083318ddcc65946dca981)