### PR TITLE
Fix WallDeathZone monster detection and collision handling

### DIFF
--- a/Assets/Scripts/Phase3/WallDeathZone.cs
+++ b/Assets/Scripts/Phase3/WallDeathZone.cs
@@ -17,20 +17,59 @@ namespace LSP.Gameplay
         [Tooltip("被墙壁碾碎的普通雕像的 Tag")]
         public string targetTag = "Statue"; // 或者是 "Enemy"，看你的项目设置
 
+        [Tooltip("可选：怪物对象身上的脚本。若命中子 Collider 也能识别并销毁整只怪物。")]
+        [SerializeField] private bool destroyMonsterControllerOwner = true;
+
+        private Collider zoneCollider;
+
+        private void Awake()
+        {
+            zoneCollider = GetComponent<Collider>();
+            if (!zoneCollider.isTrigger)
+            {
+                Debug.LogWarning("【WallDeathZone】当前 Collider 不是 Trigger。若希望使用 OnTriggerEnter，请勾选 Is Trigger。", this);
+            }
+        }
+
         private void OnTriggerEnter(Collider other)
         {
-            Debug.Log($"【WallDeathZone】墙壁碾碎了边缘的雕像: {other.name}");
-            // 1. 碰到玩家 -> 触发你配好的 Event System 死亡事件
-            if (other.CompareTag("Player"))
+            HandleContact(other);
+        }
+
+        private void OnCollisionEnter(Collision collision)
+        {
+            HandleContact(collision.collider);
+        }
+
+        private void HandleContact(Collider other)
+        {
+            if (other == null)
             {
-                Debug.Log("【WallDeathZone】玩家被墙壁挤死了！触发死亡事件。");
-                onPlayerCrushed?.Invoke();
+                return;
             }
-            // 2. 碰到雕像/怪物 -> 方案A：冷酷清场，直接销毁！
-            else if (other.CompareTag(targetTag))
+
+            // 1. 玩家
+            if (other.CompareTag("Player") || other.transform.root.CompareTag("Player"))
             {
-                Debug.Log($"【WallDeathZone】墙壁碾碎了边缘的雕像: {other.name}");
-                Destroy(other.gameObject);
+                Debug.Log("【WallDeathZone】玩家被墙壁挤死了！触发死亡事件。", other);
+                onPlayerCrushed?.Invoke();
+                return;
+            }
+
+            // 2. 按标签清场（支持标签挂在父物体）
+            if (other.CompareTag(targetTag) || other.transform.root.CompareTag(targetTag))
+            {
+                GameObject victim = other.CompareTag(targetTag) ? other.gameObject : other.transform.root.gameObject;
+                Debug.Log($"【WallDeathZone】墙壁碾碎目标: {victim.name}", victim);
+                Destroy(victim);
+                return;
+            }
+
+            // 3. 可选：只要碰到 MonsterController 任意子节点就销毁整只怪物
+            if (destroyMonsterControllerOwner && other.GetComponentInParent<MonsterController>() is MonsterController monster)
+            {
+                Debug.Log($"【WallDeathZone】检测到 MonsterController，销毁怪物: {monster.name}", monster);
+                Destroy(monster.gameObject);
             }
         }
     }


### PR DESCRIPTION
### Motivation
- The WallDeathZone only used `OnTriggerEnter` + `CompareTag(targetTag)`, which misses contacts when the wall collider is not set to `Is Trigger` or when monsters use child colliders while the tag/script is on the root object.
- Make the death/cleanup behavior robust to both trigger and collision events and to child/parent collider arrangements so monsters are reliably removed and the player is detected.

### Description
- Unified contact handling by routing `OnTriggerEnter` and `OnCollisionEnter` through a single `HandleContact(Collider)` method.
- Added an `Awake()` check that warns if the zone collider isn't configured as a trigger via `zoneCollider.isTrigger` and improved debug logging.
- Extended detection to check `other.transform.root.CompareTag(...)` so tags on parent objects are recognized when child colliders are hit.
- Added a configurable fallback flag `destroyMonsterControllerOwner` that, when enabled, destroys the `MonsterController` owner found via `GetComponentInParent<MonsterController>()` if any child collider is hit.

### Testing
- Reviewed the updated file contents with `nl -ba Assets/Scripts/Phase3/WallDeathZone.cs` to confirm the new flow and logging were applied (succeeded).
- Committed the change with `git commit -m "Fix WallDeathZone monster detection and collision handling"` and verified the diff with `git show --stat --oneline -1` (succeeded).
- Checked repository state with `git status --short` to ensure no outstanding changes (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699916c9d1408331b2879df2e65275d3)